### PR TITLE
fix(#17): web select overlay to be hidden by default

### DIFF
--- a/apps/example/components/ui/select.tsx
+++ b/apps/example/components/ui/select.tsx
@@ -1,6 +1,6 @@
 import * as SelectPrimitive from '@rn-primitives/select';
 import * as React from 'react';
-import { Platform, StyleSheet, View } from 'react-native';
+import { Platform, View } from 'react-native';
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 import { Check } from '~/lib/icons/Check';
 import { ChevronDown } from '~/lib/icons/ChevronDown';
@@ -82,7 +82,7 @@ const SelectContent = React.forwardRef<
 
   return (
     <SelectPrimitive.Portal hostName={portalHost}>
-      <SelectPrimitive.Overlay style={Platform.OS !== 'web' ? StyleSheet.absoluteFill : undefined}>
+      <SelectPrimitive.Overlay className='bg-black/20 absolute top-0 right-0 left-0 bottom-0'>
         <Animated.View entering={FadeIn} exiting={FadeOut}>
           <SelectPrimitive.Content
             ref={ref}

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/select",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Primitive select",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/select/src/select.web.tsx
+++ b/packages/select/src/select.web.tsx
@@ -149,9 +149,16 @@ function Portal({ container, children }: SelectPortalProps) {
 }
 
 const Overlay = React.forwardRef<PressableRef, SlottablePressableProps & SelectOverlayProps>(
-  ({ asChild, forceMount, ...props }, ref) => {
+  ({ asChild, forceMount, children, ...props }, ref) => {
+    const { open } = useRootContext();
+
     const Component = asChild ? Slot.Pressable : Pressable;
-    return <Component ref={ref} {...props} />;
+    return (
+      <>
+        {open && <Component ref={ref} {...props} />}
+        {children}
+      </>
+    );
   }
 );
 


### PR DESCRIPTION
# Description
In the web version on the select, radix-ui needs to the content of portal to render the item selected. The overlay component, in this case, is required on native so it is added on web to match. For that reason, the overlay which is in the portal is not handled by radix-ui and is shown by default. This PR shows the overlay when the select is open only and bumps the version.

## After merging
The `@rn-primitives/select` package will need to be released on NPM 

### Screenshots
Tested both Web and iOS, overlay works as intended.

<img width="452" alt="Screenshot 2024-07-20 at 3 23 37 PM" src="https://github.com/user-attachments/assets/1d0b0bee-722c-45a8-86f5-f3f971885f66">
<img width="950" alt="Screenshot 2024-07-20 at 3 23 47 PM" src="https://github.com/user-attachments/assets/ea1b7844-a450-4a55-ad71-208da848b8dd">
