### PR TITLE
Use global state in useModalPortalRoot()

### DIFF
--- a/apps/docs/src/content/docs/portal.mdx
+++ b/apps/docs/src/content/docs/portal.mdx
@@ -126,6 +126,57 @@ function Example() {
 }
 ```
 
+### Portal Usage in Modal Screens
+
+When using a `Stack.Screen` with `presentation` set to `'modal'`, `'formSheet'`, or similar values, you may need to use a separate `PortalHost` along with the `useModalPortalRoot()` hook to ensure correct positioning of portal content.
+
+First, add a `PortalHost` as the last child of the modal screen component:
+
+```tsx
+import { PortalHost } from '@rn-primitives/portal';
+
+const ModalComponent = () => (
+  <View style={{ flex: 1 }}>
+    {/* Modal content */}
+    <PortalHost name='my-modal-portal-host' />
+  </View>
+);
+```
+
+In the same component or within a nested container, apply the hook's `rootProps` once:
+
+```tsx
+import { useModalPortalRoot } from '@rn-primitives/useModalPortalRoot';
+
+const ModalContent = () => {
+  const { sideOffset, ...rootProps } = useModalPortalRoot('my-custom-host');
+  return (
+    <View {...rootProps}>
+      {/* Portal content will be positioned relative to the top of this View */}
+    </View>
+  );
+};
+```
+
+Then, you can render `Portal`s inside any sub-component by calling the hook and passing its `sideOffset`:
+
+```tsx
+const SubComponent = () => {
+  const { sideOffset } = useModalPortalRoot('my-custom-host');
+
+  return (
+    <DropdownMenu>
+      <DropdownTrigger>
+        <Text>Toggle Dropdown</Text>
+      </DropdownTrigger>
+      <DropdownMenuContent portalHost='my-custom-host' sideOffset={sideOffset}>
+        {/* Dropdown content */}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+```
+
 ## Props
 
 ### PortalHost


### PR DESCRIPTION
The current `useModalPortalRoot()` hook uses local state, which means you can only use its offsets within the same component where the `PortalHost` was added, or else by prop drilling. To make the hook usable everywhere, this PR adds a `hostName` parameter to the hook and saves the offsets to a `zustand` store. This way, you can call the hook wherever you define your dropdowns, selects, etc. I also added a section to the portal docs to show its usage.

## Breaking Changes
I tested the demo using this method, and I'm also using it in my own app & website. However, there's two files in the `react-native-reusables` repo that need to be updated. They each need a one-line update to pass the `hostName` to the hook, and that's it. The files are:
- [apps/docs/src/content/docs/getting-started/common-patterns.mdx](https://github.com/mrzachnugent/react-native-reusables/blob/cb428489600ab5a1a540b32db7bb97e6002631e7/apps/docs/src/content/docs/getting-started/common-patterns.mdx#L184)
- [apps/showcase/app/modal.tsx](https://github.com/mrzachnugent/react-native-reusables/blob/cb428489600ab5a1a540b32db7bb97e6002631e7/apps/showcase/app/modal.tsx#L2)