### PR TITLE
fix(avatar): fallback not showing when it should

### DIFF
--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/avatar",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Primitive avatar",
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
- Issue reported on Discord: https://discord.com/channels/1173879003191459860/1196159616887828612/1274811444684263537
- Will need to publish once it is merged.
- NativeWindUI should use this primitive once this is published. When the Avatar component was added to NativeWindUI, we combined the primitive and the styling. It has drifted since then so it should use this primitive in the future.