### PR TITLE
Add left and right to the side prop

### DIFF
--- a/apps/docs/src/content/docs/tooltip.mdx
+++ b/apps/docs/src/content/docs/tooltip.mdx
@@ -186,12 +186,12 @@ Extends [`View`](https://reactnative.dev/docs/view#props) props
 |       alignOffset       |                    number                    |       _(optional)_       |
 |         insets          |                    Insets                    |       _(optional)_       |
 |     avoidCollisions     |                   boolean                    |       _(optional)_       |
-|          align          |         'start' \| 'center' \| 'end'         |       _(optional)_       |
-|          side           |              'top' \| 'bottom' \| 'left' \| 'right' <br />(left and right are web only)              |       _(optional)_       |
+|          align          |         `start` \| `center` \| `end`         |       _(optional)_       |
+|          side           |              `top` \| `bottom` \| `left` \| `right` | `left` and `right` are web only _(optional)_       |
 |       sideOffset        |                    number                    |       _(optional)_       |
 | disablePositioningStyle |                   boolean                    | Native Only _(optional)_ |
 |    collisionBoundary    |  Element \| null \| Array\<Element \| null>  |  Web Only _(optional)_   |
-|         sticky          |            'partial' \| 'always'             |  Web Only _(optional)_   |
+|         sticky          |            `partial` \| `always`             |  Web Only _(optional)_   |
 |    hideWhenDetached     |                   boolean                    |  Web Only _(optional)_   |
 |   onEscapeKeyDown    | (ev: Event) => void | Web Only _(optional)_ |
 | onPointerDownOutside | (ev: Event) => void | Web Only _(optional)_ |

--- a/apps/docs/src/content/docs/tooltip.mdx
+++ b/apps/docs/src/content/docs/tooltip.mdx
@@ -187,7 +187,7 @@ Extends [`View`](https://reactnative.dev/docs/view#props) props
 |         insets          |                    Insets                    |       _(optional)_       |
 |     avoidCollisions     |                   boolean                    |       _(optional)_       |
 |          align          |         'start' \| 'center' \| 'end'         |       _(optional)_       |
-|          side           |              'top' \| 'bottom'               |       _(optional)_       |
+|          side           |              'top' \| 'bottom' \| 'left' \| 'right' <br />(left and right are web only)              |       _(optional)_       |
 |       sideOffset        |                    number                    |       _(optional)_       |
 | disablePositioningStyle |                   boolean                    | Native Only _(optional)_ |
 |    collisionBoundary    |  Element \| null \| Array\<Element \| null>  |  Web Only _(optional)_   |

--- a/packages/hooks/src/useRelativePosition.tsx
+++ b/packages/hooks/src/useRelativePosition.tsx
@@ -81,7 +81,7 @@ interface GetPositionArgs {
 }
 
 interface GetSidePositionArgs extends GetPositionArgs {
-  side: 'top' | 'right' | 'bottom' | 'left';
+  side: 'top' | 'bottom';
   sideOffset: number;
 }
 

--- a/packages/hooks/src/useRelativePosition.tsx
+++ b/packages/hooks/src/useRelativePosition.tsx
@@ -81,7 +81,7 @@ interface GetPositionArgs {
 }
 
 interface GetSidePositionArgs extends GetPositionArgs {
-  side: 'top' | 'bottom';
+  side: 'top' | 'right' | 'bottom' | 'left';
   sideOffset: number;
 }
 

--- a/packages/tooltip/src/tooltip.tsx
+++ b/packages/tooltip/src/tooltip.tsx
@@ -185,7 +185,7 @@ Overlay.displayName = 'OverlayNativeTooltip';
 /**
  * @info `position`, `top`, `left`, and `maxWidth` style properties are controlled internally. Opt out of this behavior on native by setting `disablePositioningStyle` to `true`.
  */
-const Content = React.forwardRef<ViewRef, TooltipContentProps>(
+const Content = React.forwardRef<ViewRef, SlottableViewProps & TooltipContentProps>(
   (
     {
       asChild = false,

--- a/packages/tooltip/src/tooltip.tsx
+++ b/packages/tooltip/src/tooltip.tsx
@@ -235,7 +235,7 @@ const Content = React.forwardRef<ViewRef, SlottableViewProps & TooltipContentPro
       alignOffset,
       insets,
       sideOffset,
-      side,
+      side: getNativeSide(side),
       disablePositioningStyle,
     });
 
@@ -274,4 +274,11 @@ export type { TooltipTriggerRef };
 
 function onStartShouldSetResponder() {
   return true;
+}
+
+function getNativeSide(side: 'left' | 'right' | 'top' | 'bottom') {
+  if (side === 'left' || side === 'right') {
+    return 'top';
+  }
+  return side;
 }

--- a/packages/tooltip/src/tooltip.tsx
+++ b/packages/tooltip/src/tooltip.tsx
@@ -2,7 +2,6 @@ import { useAugmentedRef, useRelativePosition, type LayoutPosition } from '@rn-p
 import { Portal as RNPPortal } from '@rn-primitives/portal';
 import * as Slot from '@rn-primitives/slot';
 import type {
-  PositionedContentProps,
   PressableRef,
   SlottablePressableProps,
   SlottableViewProps,
@@ -18,6 +17,7 @@ import {
   type LayoutRectangle,
 } from 'react-native';
 import type {
+  TooltipContentProps,
   TooltipOverlayProps,
   TooltipPortalProps,
   TooltipRootProps,
@@ -185,7 +185,7 @@ Overlay.displayName = 'OverlayNativeTooltip';
 /**
  * @info `position`, `top`, `left`, and `maxWidth` style properties are controlled internally. Opt out of this behavior on native by setting `disablePositioningStyle` to `true`.
  */
-const Content = React.forwardRef<ViewRef, SlottableViewProps & PositionedContentProps>(
+const Content = React.forwardRef<ViewRef, TooltipContentProps>(
   (
     {
       asChild = false,

--- a/packages/tooltip/src/tooltip.web.tsx
+++ b/packages/tooltip/src/tooltip.web.tsx
@@ -2,7 +2,6 @@ import * as Tooltip from '@radix-ui/react-tooltip';
 import { useAugmentedRef, useIsomorphicLayoutEffect } from '@rn-primitives/hooks';
 import * as Slot from '@rn-primitives/slot';
 import type {
-  PositionedContentProps,
   PressableRef,
   SlottablePressableProps,
   SlottableViewProps,
@@ -11,6 +10,7 @@ import type {
 import * as React from 'react';
 import { Pressable, View, type GestureResponderEvent } from 'react-native';
 import type {
+  TooltipContentProps,
   TooltipOverlayProps,
   TooltipPortalProps,
   TooltipRootProps,
@@ -132,7 +132,7 @@ const Overlay = React.forwardRef<PressableRef, SlottablePressableProps & Tooltip
 
 Overlay.displayName = 'OverlayWebTooltip';
 
-const Content = React.forwardRef<ViewRef, SlottableViewProps & PositionedContentProps>(
+const Content = React.forwardRef<ViewRef, TooltipContentProps>(
   (
     {
       asChild = false,

--- a/packages/tooltip/src/tooltip.web.tsx
+++ b/packages/tooltip/src/tooltip.web.tsx
@@ -132,7 +132,7 @@ const Overlay = React.forwardRef<PressableRef, SlottablePressableProps & Tooltip
 
 Overlay.displayName = 'OverlayWebTooltip';
 
-const Content = React.forwardRef<ViewRef, TooltipContentProps>(
+const Content = React.forwardRef<ViewRef, SlottableViewProps & TooltipContentProps>(
   (
     {
       asChild = false,

--- a/packages/tooltip/src/types.ts
+++ b/packages/tooltip/src/types.ts
@@ -1,4 +1,4 @@
-import type { ForceMountable, PositionedContentProps, PressableRef, SlottableViewProps } from '@rn-primitives/types';
+import type { ForceMountable, PositionedContentProps, PressableRef } from '@rn-primitives/types';
 
 interface TooltipRootProps {
   onOpenChange?: (open: boolean) => void;
@@ -39,11 +39,17 @@ interface TooltipTriggerRef extends PressableRef {
   close: () => void;
 }
 
-interface TooltipContentProps extends SlottableViewProps, Omit<PositionedContentProps, 'side'> {
+interface TooltipContentProps extends Omit<PositionedContentProps, 'side'> {
   /**
    * Left and right are only supported on web.
    */
   side?: 'top' | 'right' | 'bottom' | 'left';
 }
 
-export type { TooltipContentProps, TooltipOverlayProps, TooltipPortalProps, TooltipRootProps, TooltipTriggerRef };
+export type {
+  TooltipContentProps,
+  TooltipOverlayProps,
+  TooltipPortalProps,
+  TooltipRootProps,
+  TooltipTriggerRef,
+};

--- a/packages/tooltip/src/types.ts
+++ b/packages/tooltip/src/types.ts
@@ -1,4 +1,4 @@
-import type { ForceMountable, PressableRef } from '@rn-primitives/types';
+import type { ForceMountable, PositionedContentProps, PressableRef, SlottableViewProps } from '@rn-primitives/types';
 
 interface TooltipRootProps {
   onOpenChange?: (open: boolean) => void;
@@ -39,4 +39,11 @@ interface TooltipTriggerRef extends PressableRef {
   close: () => void;
 }
 
-export type { TooltipOverlayProps, TooltipPortalProps, TooltipRootProps, TooltipTriggerRef };
+interface TooltipContentProps extends SlottableViewProps, Omit<PositionedContentProps, 'side'> {
+  /**
+   * Left and right are only supported on web.
+   */
+  side?: 'top' | 'right' | 'bottom' | 'left';
+}
+
+export type { TooltipContentProps, TooltipOverlayProps, TooltipPortalProps, TooltipRootProps, TooltipTriggerRef };

--- a/packages/tooltip/src/types.ts
+++ b/packages/tooltip/src/types.ts
@@ -41,7 +41,7 @@ interface TooltipTriggerRef extends PressableRef {
 
 interface TooltipContentProps extends Omit<PositionedContentProps, 'side'> {
   /**
-   * Left and right are only supported on web.
+   * `left` and `right` are only supported on web.
    */
   side?: 'top' | 'right' | 'bottom' | 'left';
 }


### PR DESCRIPTION
So, I noticed that the side prop in the tooltip does not accept the left or right values. But technically, it does. So, maybe it is a mistake, and this fixes it, or the tooltip needs to have a different side prop from PositionContentProps