### PR TITLE
fix: make `select.web` consistent

### DIFF
--- a/packages/select/src/select.web.tsx
+++ b/packages/select/src/select.web.tsx
@@ -228,7 +228,9 @@ const ItemContext = React.createContext<{
 const Item = React.forwardRef<ItemRef, ItemProps>(
   ({ asChild, closeOnPress = true, label, value, children, ...props }, ref) => {
     const { labelForValueRef } = useRootContext();
-    labelForValueRef.current[value] = label;
+    if (!(value in labelForValueRef.current)) {
+      labelForValueRef.current[value] = label;
+    }
     return (
       <ItemContext.Provider value={{ itemValue: value, label: label }}>
         <Slot.Pressable ref={ref} {...props}>


### PR DESCRIPTION
This solves #26 in making the `<Select>` component consistent on web and native.

For each `<Item>` component, keep track of its `value` to `label` mapping on the `<Root>` component by passing a `MutableRefObject` that stores the mapping from `<Root>` to `<Item>` via context.

On render, `<Item>` sets the label for its value. `<Root>` can then call `onValueChange` with `labelForValueRef.current[val] ?? val`, allowing feature parity with the native implementation.

This approach works perfectly. Since `Item` must be rendered before it can be interacted with and emit events, this always ensures that `labelForValueRef[val]` exists before `onStrValueChange` is called. Furthermore, since the `value` and `defaultValue` prop requires `{ value: string, label: string }`, the initial render also does not have any issues.