### PR TITLE
fix: reactivity of content layout

### DIFF
--- a/packages/hooks/src/useRelativePosition.tsx
+++ b/packages/hooks/src/useRelativePosition.tsx
@@ -2,10 +2,6 @@ import type { Insets } from '@rn-primitives/types';
 import * as React from 'react';
 import { Dimensions, type LayoutRectangle, type ScaledSize, type ViewStyle } from 'react-native';
 
-const POSITION_ABSOLUTE: ViewStyle = {
-  position: 'absolute',
-};
-
 const HIDDEN_CONTENT: ViewStyle = {
   position: 'absolute',
   opacity: 0,
@@ -213,7 +209,7 @@ function getContentStyle({
   dimensions,
 }: GetContentStyleArgs) {
   return Object.assign(
-    POSITION_ABSOLUTE,
+    { position: 'absolute' } as const,
     getSidePosition({
       side,
       triggerPosition,


### PR DESCRIPTION
Solves #60.

Previously, there was a bug with `useRelativePosition` returning a **non-changing object reference** to a module-level `POSITION_ABSOLUTE` variable.

As a result, components and hooks that relied on the `positionStyle` returned would not detect any changes when the layout changed.

* Side note, `getContentStyle` also incorrectly mutated `POSITION_ABSOLUTE` on each call due to `Object.assign`, which did not cause bugs yet thanks to `getSidePosition` and `getAlignPosition` overriding all values, but might introduce unexpected effects in the future.

To fix this, we return a new object per call to `getContentStyle`. Memoization is already properly handled when `useMemo` is used in `useRelativePosition`, thus no performance penalty is observed.

### Demo

To demonstrate the fix, I use my application where `insets` is updated on a `<Popover>` component in response to the keyboard showing.

This is the behaviour before:

https://github.com/user-attachments/assets/96c147eb-1f2d-45df-a79e-df1c8f63824a

And this is the corrected behaviour after this fix:

https://github.com/user-attachments/assets/9bd90a21-b9bc-4c2a-85dc-abc65bdb9ef7