### PR TITLE
chore: bump versions for portal and hooks + adjustments for prs 62 + 68

### DIFF
--- a/apps/expo-nativewind/package.json
+++ b/apps/expo-nativewind/package.json
@@ -66,7 +66,7 @@
     "tailwind-merge": "^2.5.3",
     "tailwindcss": "^3.4.13",
     "tailwindcss-animate": "^1.0.7",
-    "zustand": "^4.4.7"
+    "zustand": "^5.0.4"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",

--- a/apps/expo-stylesheet/package.json
+++ b/apps/expo-stylesheet/package.json
@@ -60,7 +60,7 @@
     "react-native-screens": "~4.1.0",
     "react-native-svg": "15.8.0",
     "react-native-web": "~0.19.13",
-    "zustand": "^4.4.7"
+    "zustand": "^5.0.4"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/hooks",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Primitive hooks",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/hooks/src/useRelativePosition.tsx
+++ b/packages/hooks/src/useRelativePosition.tsx
@@ -1,13 +1,6 @@
 import type { Insets } from '@rn-primitives/types';
 import * as React from 'react';
-import { Dimensions, type LayoutRectangle, type ScaledSize, type ViewStyle } from 'react-native';
-
-const HIDDEN_CONTENT: ViewStyle = {
-  position: 'absolute',
-  opacity: 0,
-  top: 9999999,
-  zIndex: -9999999,
-};
+import { Dimensions, type LayoutRectangle, type ScaledSize } from 'react-native';
 
 type UseRelativePositionArgs = Omit<
   GetContentStyleArgs,
@@ -36,7 +29,12 @@ export function useRelativePosition({
       return {};
     }
     if (!triggerPosition || !contentLayout) {
-      return HIDDEN_CONTENT;
+      return {
+        position: 'absolute',
+        opacity: 0,
+        top: dimensions.height,
+        zIndex: -9999999,
+      } as const;
     }
     return getContentStyle({
       align,

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/portal",
-  "version": "2.0.0",
+  "version": "1.2.0",
   "description": "Primitive portal",
   "license": "MIT",
   "main": "dist/index.js",
@@ -26,7 +26,7 @@
     "pub:release": "pnpm publish --access public"
   },
   "dependencies": {
-    "zustand": "^5.0.3"
+    "zustand": "^5.0.4"
   },
   "devDependencies": {
     "@tsconfig/react-native": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,8 +353,8 @@ importers:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.15)
       zustand:
-        specifier: ^4.4.7
-        version: 4.5.5(@types/react@18.3.12)(react@18.3.1)
+        specifier: ^5.0.4
+        version: 5.0.4(@types/react@18.3.12)(react@18.3.1)(use-sync-external-store@1.2.2(react@18.3.1))
     devDependencies:
       '@babel/core':
         specifier: ^7.26.0
@@ -513,8 +513,8 @@ importers:
         specifier: ~0.19.13
         version: 0.19.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       zustand:
-        specifier: ^4.4.7
-        version: 4.5.5(@types/react@18.3.12)(react@18.3.1)
+        specifier: ^5.0.4
+        version: 5.0.4(@types/react@18.3.12)(react@18.3.1)(use-sync-external-store@1.2.2(react@18.3.1))
     devDependencies:
       '@babel/core':
         specifier: ^7.26.0
@@ -1208,8 +1208,8 @@ importers:
         specifier: '*'
         version: 0.19.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       zustand:
-        specifier: ^5.0.3
-        version: 5.0.3(@types/react@18.3.12)(react@18.3.1)(use-sync-external-store@1.2.2(react@18.3.1))
+        specifier: ^5.0.4
+        version: 5.0.4(@types/react@18.3.12)(react@18.3.1)(use-sync-external-store@1.2.2(react@18.3.1))
     devDependencies:
       '@tsconfig/react-native':
         specifier: ^1.0.1
@@ -2936,7 +2936,7 @@ packages:
   '@floating-ui/react-dom@2.1.2':
     resolution: {integrity: sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==}
     peerDependencies:
-      react: '>=16.8.0'
+      react: 19.0.0
       react-dom: '>=16.8.0'
 
   '@floating-ui/utils@0.2.8':
@@ -8704,23 +8704,8 @@ packages:
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
-  zustand@4.5.5:
-    resolution: {integrity: sha512-+0PALYNJNgK6hldkgDq2vLrw5f6g/jCInz52n9RTpropGgeAf/ioFUCdtsjCqu4gNhW9D01rUQBROoRjdzyn2Q==}
-    engines: {node: '>=12.7.0'}
-    peerDependencies:
-      '@types/react': '>=16.8'
-      immer: '>=9.0.6'
-      react: '>=16.8'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      immer:
-        optional: true
-      react:
-        optional: true
-
-  zustand@5.0.3:
-    resolution: {integrity: sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==}
+  zustand@5.0.4:
+    resolution: {integrity: sha512-39VFTN5InDtMd28ZhjLyuTnlytDr9HfwO512Ai4I8ZABCoyAj4F1+sr7sD1jP/+p7k77Iko0Pb5NhgBFDCX0kQ==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@types/react': '>=18.0.0'
@@ -17189,14 +17174,7 @@ snapshots:
 
   zod@3.23.8: {}
 
-  zustand@4.5.5(@types/react@18.3.12)(react@18.3.1):
-    dependencies:
-      use-sync-external-store: 1.2.2(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 18.3.12
-      react: 18.3.1
-
-  zustand@5.0.3(@types/react@18.3.12)(react@18.3.1)(use-sync-external-store@1.2.2(react@18.3.1)):
+  zustand@5.0.4(@types/react@18.3.12)(react@18.3.1)(use-sync-external-store@1.2.2(react@18.3.1)):
     optionalDependencies:
       '@types/react': 18.3.12
       react: 18.3.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the "zustand" dependency to version ^5.0.4 in multiple packages.
  - Adjusted package versions for better alignment across the project.

- **Refactor**
  - Improved the calculation of hidden content positioning to use the actual screen height, enhancing compatibility with different devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->