### PR TITLE
Fix: Align PositionedContentProps style with Pressable style prop

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,4 @@
-import type { Pressable, Text, View, ViewStyle } from 'react-native';
+import type { Pressable, StyleProp, Text, View, ViewStyle } from 'react-native';
 
 type ComponentPropsWithAsChild<T extends React.ElementType<any>> =
   React.ComponentPropsWithoutRef<T> & { asChild?: boolean };
@@ -36,7 +36,7 @@ type FocusOutsideEvent = CustomEvent<{ originalEvent: FocusEvent }>;
  */
 interface PositionedContentProps {
   forceMount?: true | undefined;
-  style?: ViewStyle;
+  style?: StyleProp<ViewStyle>;
   alignOffset?: number;
   insets?: Insets;
   avoidCollisions?: boolean;


### PR DESCRIPTION
Components using `PositionedContentProps` are having their `style` type definitions from normal `View`s and `Pressable`s overwritten. `PositionedContentProps` are only typed to receive a single style object even though they actually work with arrays of style objects too

[Pressable Props](https://github.com/facebook/react-native/blob/d33c2d1435fd87256fc76eb8d31fbb6510f50230/packages/react-native/Libraries/Components/Pressable/Pressable.d.ts#L153-L156)
[View Props](https://github.com/facebook/react-native/blob/ca1ecefc5150acf9ce3e0ce83a2f4a064a83ba9d/packages/react-native/Libraries/Components/View/ViewPropTypes.d.ts#L208)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the flexibility of the `style` property in certain components to support a wider range of style formats, including arrays and other variations accepted by React Native.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->