### PR TITLE
fix(docs): update wrong Root types inside navigation-menu.mdx

### DIFF
--- a/apps/docs/src/content/docs/navigation-menu.mdx
+++ b/apps/docs/src/content/docs/navigation-menu.mdx
@@ -177,8 +177,8 @@ Extends [`View`](https://reactnative.dev/docs/view#props) props
 
 |       Prop        |            Type            |         Note          |
 | :---------------: | :------------------------: | :-------------------: |
-|      value\*      |          boolean           |                       |
-|  onValueChange\*  |  (value: boolean) => void  |                       |
+|      value\*      |          string | undefined           |            |
+|  onValueChange\*  |  (value: string | undefined) => void  |            |
 |      asChild      |          boolean           |     _(optional)_      |
 |   delayDuration   |           number           | Web only _(optional)_ |
 | skipDelayDuration |           number           | Web only _(optional)_ |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the navigation menu documentation to reflect changes in the `Root` component's prop types, switching from boolean to string-based value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->