### PR TITLE
fix: unable to customize css styles of 'toolbar' component in Web Platform

### DIFF
--- a/packages/toolbar/src/toolbar.web.tsx
+++ b/packages/toolbar/src/toolbar.web.tsx
@@ -23,7 +23,7 @@ const Root = React.forwardRef<RootRef, RootProps>(
     const Component = asChild ? Slot.View : View;
     return (
       <Toolbar.Root orientation={orientation} dir={dir} loop={loop} asChild>
-        <Component ref={ref} {...props} />
+        <Component ref={ref} style={style} {...props} />
       </Toolbar.Root>
     );
   }
@@ -54,7 +54,7 @@ const ToggleGroup = React.forwardRef<ToggleGroupRef, ToggleGroupProps>(
           disabled={disabled}
           asChild
         >
-          <Component ref={ref} {...viewProps} />
+          <Component ref={ref} style={style} {...viewProps} />
         </Toolbar.ToggleGroup>
       </ToggleGroupContext.Provider>
     );
@@ -101,7 +101,7 @@ const ToggleItem = React.forwardRef<ToggleItemRef, ToggleItemProps>(
     const Component = asChild ? Slot.Pressable : Pressable;
     return (
       <Toolbar.ToggleItem value={itemValue} asChild>
-        <Component ref={ref} onPress={onPress} role='button' {...props} />
+        <Component ref={ref} onPress={onPress} role='button' style={style} {...props} />
       </Toolbar.ToggleItem>
     );
   }
@@ -112,7 +112,7 @@ ToggleItem.displayName = 'ToggleItemWebToolbar';
 const Separator = React.forwardRef<SeparatorRef, SeparatorProps>(
   ({ asChild, style, ...props }, ref) => {
     const Component = asChild ? Slot.View : View;
-    return <Component ref={ref} {...props} />;
+    return <Component ref={ref} style={style} {...props} />;
   }
 );
 
@@ -122,7 +122,7 @@ const Link = React.forwardRef<LinkRef, LinkProps>(({ asChild, style, ...props },
   const Component = asChild ? Slot.Pressable : Pressable;
   return (
     <Toolbar.Link asChild>
-      <Component ref={ref} {...props} />
+      <Component ref={ref} style={style} {...props} />
     </Toolbar.Link>
   );
 });
@@ -133,7 +133,7 @@ const Button = React.forwardRef<ButtonRef, ButtonProps>(({ asChild, style, ...pr
   const Component = asChild ? Slot.Pressable : Pressable;
   return (
     <Toolbar.Button asChild>
-      <Component ref={ref} role='button' {...props} />
+      <Component ref={ref} role='button' style={style} {...props} />
     </Toolbar.Button>
   );
 });


### PR DESCRIPTION
While working on #105 I found a bug. CSS styles passed through `"toolbar"` component doesn't have any effect in Web platform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Web toolbar components now honor the style prop across all elements (Root, Toggle Group, Toggle Item, Separator, Link, Button), enabling consistent custom styling.
- Bug Fixes
  - Resolved previously ignored style prop on web toolbar components, ensuring passed-in styles are applied as expected.
- Documentation
  - Clarified that styling can be applied directly via the style prop on all web toolbar components without changing the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->