### PR TITLE
Fix ref being undefined for measure functions

### DIFF
--- a/packages/dropdown-menu/src/dropdown-menu.tsx
+++ b/packages/dropdown-menu/src/dropdown-menu.tsx
@@ -1,5 +1,5 @@
+import { augmentRef } from '@rn-primitives/utils';
 import {
-  useAugmentedRef,
   useControllableState,
   useRelativePosition,
   type LayoutPosition,
@@ -109,36 +109,36 @@ const Trigger = React.forwardRef<TriggerRef, TriggerProps>(
   ({ asChild, onPress: onPressProp, disabled = false, ...props }, ref) => {
     const { open, onOpenChange, setTriggerPosition } = useRootContext();
 
-    const augmentedRef = useAugmentedRef({
-      ref,
-      methods: {
-        open: () => {
-          onOpenChange(true);
-          augmentedRef.current?.measure((_x, _y, width, height, pageX, pageY) => {
-            setTriggerPosition({ width, pageX, pageY: pageY, height });
-          });
-        },
-        close: () => {
-          setTriggerPosition(null);
-          onOpenChange(false);
-        },
-      },
-    });
-
     function onPress(ev: GestureResponderEvent) {
       if (disabled) return;
-      augmentedRef.current?.measure((_x, _y, width, height, pageX, pageY) => {
+      if (typeof ref === 'function') return;
+      ref?.current?.measure((_x, _y, width, height, pageX, pageY) => {
         setTriggerPosition({ width, pageX, pageY: pageY, height });
       });
       const newValue = !open;
       onOpenChange(newValue);
       onPressProp?.(ev);
     }
-
+    
+    const methods = {
+      open: () => {
+        onOpenChange(true);
+        (ref as React.RefObject<TriggerRef>)?.current?.measure(
+          (_x, _y, width, height, pageX, pageY) => {
+            setTriggerPosition({ width, pageX, pageY: pageY, height });
+          }
+        );
+      },
+      close: () => {
+        setTriggerPosition(null);
+        onOpenChange(false);
+      },
+    };
+    
     const Component = asChild ? Slot.Pressable : Pressable;
     return (
       <Component
-        ref={augmentedRef}
+        ref={(self) => augmentRef(ref, self, methods)}
         aria-disabled={disabled ?? undefined}
         role='button'
         onPress={onPress}

--- a/packages/hover-card/package.json
+++ b/packages/hover-card/package.json
@@ -36,6 +36,7 @@
     "@rn-primitives/popover": "workspace:*",
     "@rn-primitives/slot": "workspace:*",
     "@rn-primitives/hooks": "workspace:*",
+    "@rn-primitives/utils": "workspace:*",
     "@rn-primitives/types": "workspace:*"
   },
   "devDependencies": {

--- a/packages/menubar/src/menubar.tsx
+++ b/packages/menubar/src/menubar.tsx
@@ -1,5 +1,5 @@
+import { augmentRef } from '@rn-primitives/utils';
 import {
-  useAugmentedRef,
   useControllableState,
   useRelativePosition,
   type LayoutPosition,
@@ -124,13 +124,13 @@ function useMenuContext() {
 
 const Trigger = React.forwardRef<TriggerRef, TriggerProps>(
   ({ asChild, onPress: onPressProp, disabled = false, ...props }, ref) => {
-    const triggerRef = useAugmentedRef({ ref });
     const { value, onValueChange, setTriggerPosition } = useRootContext();
     const { value: menuValue } = useMenuContext();
 
     function onPress(ev: GestureResponderEvent) {
       if (disabled) return;
-      triggerRef.current?.measure((_x, _y, width, height, pageX, pageY) => {
+      if (typeof ref === 'function') return;
+      ref?.current?.measure((_x, _y, width, height, pageX, pageY) => {
         setTriggerPosition({ width, pageX, pageY, height });
       });
 
@@ -141,7 +141,7 @@ const Trigger = React.forwardRef<TriggerRef, TriggerProps>(
     const Component = asChild ? Slot.Pressable : Pressable;
     return (
       <Component
-        ref={triggerRef}
+        ref={(self) => augmentRef(ref, self)} // copy hook behaviour if not needed then pass 'ref' instead
         aria-disabled={disabled ?? undefined}
         role='button'
         onPress={onPress}

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@radix-ui/react-popover": "^1.1.14",
     "@rn-primitives/hooks": "workspace:*",
+    "@rn-primitives/utils": "workspace:*",
     "@rn-primitives/slot": "workspace:*",
     "@rn-primitives/types": "workspace:*"
   },

--- a/packages/popover/src/popover.tsx
+++ b/packages/popover/src/popover.tsx
@@ -1,4 +1,5 @@
-import { useAugmentedRef, useRelativePosition, type LayoutPosition } from '@rn-primitives/hooks';
+import { augmentRef } from '@rn-primitives/utils';
+import { useRelativePosition, type LayoutPosition } from '@rn-primitives/hooks';
 import { Portal as RNPPortal } from '@rn-primitives/portal';
 import * as Slot from '@rn-primitives/slot';
 import * as React from 'react';
@@ -81,35 +82,35 @@ const Trigger = React.forwardRef<TriggerRef, TriggerProps>(
   ({ asChild, onPress: onPressProp, disabled = false, ...props }, ref) => {
     const { onOpenChange, open, setTriggerPosition } = useRootContext();
 
-    const augmentedRef = useAugmentedRef({
-      ref,
-      methods: {
-        open: () => {
-          onOpenChange(true);
-          augmentedRef.current?.measure((_x, _y, width, height, pageX, pageY) => {
-            setTriggerPosition({ width, pageX, pageY: pageY, height });
-          });
-        },
-        close: () => {
-          setTriggerPosition(null);
-          onOpenChange(false);
-        },
-      },
-    });
-
     function onPress(ev: GestureResponderEvent) {
       if (disabled) return;
-      augmentedRef.current?.measure((_x, _y, width, height, pageX, pageY) => {
+      if (typeof ref === 'function') return;
+      ref?.current?.measure((_x, _y, width, height, pageX, pageY) => {
         setTriggerPosition({ width, pageX, pageY: pageY, height });
       });
       onOpenChange(!open);
       onPressProp?.(ev);
     }
 
+    const methods = {
+      open: () => {
+        onOpenChange(true);
+        (ref as React.RefObject<TriggerRef>)?.current?.measure(
+          (_x, _y, width, height, pageX, pageY) => {
+            setTriggerPosition({ width, pageX, pageY: pageY, height });
+          }
+        );
+      },
+      close: () => {
+        setTriggerPosition(null);
+        onOpenChange(false);
+      },
+    };
+
     const Component = asChild ? Slot.Pressable : Pressable;
     return (
       <Component
-        ref={augmentedRef}
+        ref={(self) => augmentRef(ref, self, methods)}
         aria-disabled={disabled ?? undefined}
         role='button'
         onPress={onPress}

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@radix-ui/react-select": "^2.2.5",
     "@rn-primitives/hooks": "workspace:*",
+    "@rn-primitives/utils": "workspace:*",
     "@rn-primitives/slot": "workspace:*",
     "@rn-primitives/types": "workspace:*"
   },

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@radix-ui/react-tooltip": "^1.2.7",
     "@rn-primitives/hooks": "workspace:*",
+    "@rn-primitives/utils": "workspace:*",
     "@rn-primitives/slot": "workspace:*",
     "@rn-primitives/types": "workspace:*"
   },

--- a/packages/tooltip/src/tooltip.tsx
+++ b/packages/tooltip/src/tooltip.tsx
@@ -1,4 +1,5 @@
-import { useAugmentedRef, useRelativePosition, type LayoutPosition } from '@rn-primitives/hooks';
+import { augmentRef } from '@rn-primitives/utils';
+import { useRelativePosition, type LayoutPosition } from '@rn-primitives/hooks';
 import { Portal as RNPPortal } from '@rn-primitives/portal';
 import * as Slot from '@rn-primitives/slot';
 import * as React from 'react';
@@ -89,36 +90,34 @@ const Trigger = React.forwardRef<TriggerRef, TriggerProps>(
   ({ asChild, onPress: onPressProp, disabled = false, ...props }, ref) => {
     const { open, onOpenChange, setTriggerPosition } = useTooltipContext();
 
-    const augmentedRef = useAugmentedRef({
-      ref,
-      methods: {
-        open: () => {
-          onOpenChange(true);
-          augmentedRef.current?.measure((_x, _y, width, height, pageX, pageY) => {
-            setTriggerPosition({ width, pageX, pageY: pageY, height });
-          });
-        },
-        close: () => {
-          setTriggerPosition(null);
-          onOpenChange(false);
-        },
-      },
-    });
-
     function onPress(ev: GestureResponderEvent) {
       if (disabled) return;
-      augmentedRef.current?.measure((_x, _y, width, height, pageX, pageY) => {
+      if (typeof ref === 'function') return;
+      ref?.current?.measure((_x, _y, width, height, pageX, pageY) => {
         setTriggerPosition({ width, pageX, pageY: pageY, height });
       });
       const newValue = !open;
       onOpenChange(newValue);
       onPressProp?.(ev);
     }
+    
+    const methods = {
+      open: () => {
+        onOpenChange(true);
+        (ref as React.RefObject<TriggerRef>)?.current?.measure((_x, _y, width, height, pageX, pageY) => {
+          setTriggerPosition({ width, pageX, pageY: pageY, height });
+        });
+      },
+      close: () => {
+        setTriggerPosition(null);
+        onOpenChange(false);
+      },
+    };
 
     const Component = asChild ? Slot.Pressable : Pressable;
     return (
       <Component
-        ref={augmentedRef}
+        ref={(self) => augmentRef(ref, self, methods)}
         aria-disabled={disabled ?? undefined}
         role='button'
         onPress={onPress}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -58,4 +58,15 @@ const EmptyGestureResponderEvent: GestureResponderEvent = {
   type: '',
 };
 
-export { ToggleGroupUtils, EmptyGestureResponderEvent };
+function augmentRef<T>(
+  userRef: React.Ref<T>,
+  componentRef: T,
+  methods?: Record<string, (...args: any[]) => any>
+) {
+  if (!userRef || !componentRef) return;
+  if (typeof userRef === 'function') return; // copy hook behaviour
+  Object.assign(componentRef, methods);
+  userRef.current = componentRef;
+}
+
+export { ToggleGroupUtils, EmptyGestureResponderEvent, augmentRef };


### PR DESCRIPTION
Please see [this issue](https://github.com/roninoss/rn-primitives/issues/110)
Updated a few component primitives **AND** the utils package.  
I decided not to modify the .web components since the hook works on web, but honestly, i would just remove the hook at this point.
This should fixe all measure functions but might have a few other ones too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized internal ref handling mechanism across multiple menu, dropdown, card, and input components for improved code consistency, maintainability, and overall performance.
  * Added new utility function to provide unified ref augmentation support across the entire component library for better code organization.
  * Zero impact on public API, component behavior, or any end-user functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->