### PR TITLE
Accessibility overhaul (native only; .web.tsx untouched)

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/accordion",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive accordion",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/accordion/src/accordion.tsx
+++ b/packages/accordion/src/accordion.tsx
@@ -67,7 +67,6 @@ function useRootContext() {
 }
 
 type AccordionItemContext = ItemProps & {
-  nativeID: string;
   isExpanded: boolean;
 };
 
@@ -76,7 +75,6 @@ type ItemComponentProps = ItemProps & React.RefAttributes<ItemRef>;
 
 const Item = ({ asChild, value, disabled, ref, ...viewProps }: ItemComponentProps) => {
   const { value: rootValue } = useRootContext();
-  const nativeID = React.useId();
 
   const Component = asChild ? Slot : View;
   return (
@@ -84,7 +82,6 @@ const Item = ({ asChild, value, disabled, ref, ...viewProps }: ItemComponentProp
       value={{
         value,
         disabled,
-        nativeID,
         isExpanded: isItemExpanded(rootValue, value),
       }}
     >
@@ -139,7 +136,7 @@ const Trigger = ({
     value: rootValue,
     collapsible,
   } = useRootContext();
-  const { nativeID, disabled: itemDisabled, value, isExpanded } = useItemContext();
+  const { disabled: itemDisabled, value, isExpanded } = useItemContext();
 
   function onPress(ev: GestureResponderEvent) {
     if (rootDisabled || itemDisabled) return;
@@ -165,14 +162,14 @@ const Trigger = ({
   return (
     <Component
       ref={ref}
-      nativeID={nativeID}
-      aria-disabled={isDisabled}
       role='button'
-      onPress={onPress}
+      aria-disabled={isDisabled}
+      aria-expanded={isExpanded}
       accessibilityState={{
         expanded: isExpanded,
         disabled: isDisabled,
       }}
+      onPress={onPress}
       disabled={isDisabled}
       {...props}
     />
@@ -183,8 +180,7 @@ Trigger.displayName = 'TriggerNativeAccordion';
 type ContentComponentProps = ContentProps & React.RefAttributes<ContentRef>;
 
 const Content = ({ asChild, forceMount, ref, ...props }: ContentComponentProps) => {
-  const { type } = useRootContext();
-  const { nativeID, isExpanded } = useItemContext();
+  const { isExpanded } = useItemContext();
 
   if (!forceMount) {
     if (!isExpanded) {
@@ -197,8 +193,7 @@ const Content = ({ asChild, forceMount, ref, ...props }: ContentComponentProps) 
     <Component
       ref={ref}
       aria-hidden={!(forceMount || isExpanded)}
-      aria-labelledby={nativeID}
-      role={type === 'single' ? 'region' : 'summary'}
+      role='region'
       {...props}
     />
   );

--- a/packages/alert-dialog/package.json
+++ b/packages/alert-dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/alert-dialog",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive alert dialog",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/alert-dialog/src/alert-dialog.tsx
+++ b/packages/alert-dialog/src/alert-dialog.tsx
@@ -1,4 +1,8 @@
-import { useControllableState } from '@rn-primitives/hooks';
+import {
+  useAccessibilityFocus,
+  useComposedRefs,
+  useControllableState,
+} from '@rn-primitives/hooks';
 import { Portal as RNPPortal } from '@rn-primitives/portal';
 import { Slot } from '@rn-primitives/slot';
 import * as React from 'react';
@@ -87,7 +91,9 @@ const Trigger = ({
     <Component
       ref={ref}
       aria-disabled={disabled ?? undefined}
+      aria-expanded={value}
       role='button'
+      accessibilityState={{ disabled: disabled ?? false, expanded: value }}
       onPress={onPress}
       disabled={disabled ?? undefined}
       {...props}
@@ -134,7 +140,9 @@ Overlay.displayName = 'OverlayNativeAlertDialog';
 type ContentComponentProps = ContentProps & React.RefAttributes<ContentRef>;
 
 const Content = ({ asChild, forceMount, ref, ...props }: ContentComponentProps) => {
-  const { open: value, nativeID, onOpenChange } = useRootContext();
+  const { open: value, onOpenChange } = useRootContext();
+  const accessibilityFocusRef = useAccessibilityFocus<ContentRef>(value);
+  const composedRef = useComposedRefs(ref, accessibilityFocusRef);
 
   React.useEffect(() => {
     const backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
@@ -156,12 +164,10 @@ const Content = ({ asChild, forceMount, ref, ...props }: ContentComponentProps) 
   const Component = asChild ? Slot : View;
   return (
     <Component
-      ref={ref}
+      ref={composedRef}
       role='alertdialog'
-      nativeID={nativeID}
-      aria-labelledby={`${nativeID}_label`}
-      aria-describedby={`${nativeID}_desc`}
       aria-modal={true}
+      onAccessibilityEscape={() => onOpenChange(false)}
       {...props}
     />
   );
@@ -191,6 +197,7 @@ const Cancel = ({
       ref={ref}
       aria-disabled={disabled ?? undefined}
       role='button'
+      accessibilityState={{ disabled: disabled ?? false }}
       onPress={onPress}
       disabled={disabled ?? undefined}
       {...props}
@@ -222,6 +229,7 @@ const Action = ({
       ref={ref}
       aria-disabled={disabled ?? undefined}
       role='button'
+      accessibilityState={{ disabled: disabled ?? false }}
       onPress={onPress}
       disabled={disabled ?? undefined}
       {...props}
@@ -233,18 +241,16 @@ Action.displayName = 'ActionNativeAlertDialog';
 type TitleComponentProps = TitleProps & React.RefAttributes<TitleRef>;
 
 const Title = ({ asChild, ref, ...props }: TitleComponentProps) => {
-  const { nativeID } = useRootContext();
   const Component = asChild ? Slot : Text;
-  return <Component ref={ref} role='heading' nativeID={`${nativeID}_label`} {...props} />;
+  return <Component ref={ref} role='heading' {...props} />;
 };
 
 Title.displayName = 'TitleNativeAlertDialog';
 type DescriptionComponentProps = DescriptionProps & React.RefAttributes<DescriptionRef>;
 
 const Description = ({ asChild, ref, ...props }: DescriptionComponentProps) => {
-  const { nativeID } = useRootContext();
   const Component = asChild ? Slot : Text;
-  return <Component ref={ref} nativeID={`${nativeID}_desc`} {...props} />;
+  return <Component ref={ref} {...props} />;
 };
 
 Description.displayName = 'DescriptionNativeAlertDialog';

--- a/packages/aspect-ratio/package.json
+++ b/packages/aspect-ratio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/aspect-ratio",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive aspect ratio",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/avatar",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive avatar",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/checkbox",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive checkbox",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/checkbox/src/checkbox.tsx
+++ b/packages/checkbox/src/checkbox.tsx
@@ -4,11 +4,7 @@ import * as React from 'react';
 import { GestureResponderEvent, Pressable, View } from 'react-native';
 import type { IndicatorProps, IndicatorRef, RootProps, RootRef } from './types';
 
-interface RootContext extends RootProps {
-  nativeID?: string;
-}
-
-const CheckboxContext = React.createContext<RootContext | null>(null);
+const CheckboxContext = React.createContext<RootProps | null>(null);
 type RootComponentProps = RootProps & React.RefAttributes<RootRef>;
 
 const Root = ({
@@ -16,7 +12,6 @@ const Root = ({
   disabled = false,
   checked,
   onCheckedChange,
-  nativeID,
   ref,
   ...props
 }: RootComponentProps) => {
@@ -26,7 +21,6 @@ const Root = ({
         disabled,
         checked,
         onCheckedChange,
-        nativeID,
       }}
     >
       <Trigger ref={ref} {...props} />
@@ -48,7 +42,7 @@ function useCheckboxContext() {
 type TriggerComponentProps = SlottablePressableProps & React.RefAttributes<PressableRef>;
 
 const Trigger = ({ asChild, onPress: onPressProp, ref, ...props }: TriggerComponentProps) => {
-  const { disabled, checked, onCheckedChange, nativeID } = useCheckboxContext();
+  const { disabled, checked, onCheckedChange } = useCheckboxContext();
 
   function onPress(ev: GestureResponderEvent) {
     if (disabled) return;
@@ -61,7 +55,6 @@ const Trigger = ({ asChild, onPress: onPressProp, ref, ...props }: TriggerCompon
   return (
     <Component
       ref={ref}
-      nativeID={nativeID}
       aria-disabled={disabled}
       role='checkbox'
       aria-checked={checked}

--- a/packages/collapsible/package.json
+++ b/packages/collapsible/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/collapsible",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive collapsible",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/collapsible/src/collapsible.tsx
+++ b/packages/collapsible/src/collapsible.tsx
@@ -12,7 +12,7 @@ import type {
   TriggerRef,
 } from './types';
 
-const CollapsibleContext = React.createContext<(RootContext & { nativeID: string }) | null>(null);
+const CollapsibleContext = React.createContext<RootContext | null>(null);
 type RootComponentProps = RootProps & React.RefAttributes<RootRef>;
 
 const Root = ({
@@ -24,7 +24,6 @@ const Root = ({
   ref,
   ...viewProps
 }: RootComponentProps) => {
-  const nativeID = React.useId();
   const [open = false, onOpenChange] = useControllableState({
     prop: openProp,
     defaultProp: defaultOpen,
@@ -38,7 +37,6 @@ const Root = ({
         disabled,
         open,
         onOpenChange,
-        nativeID,
       }}
     >
       <Component ref={ref} {...viewProps} />
@@ -66,7 +64,7 @@ const Trigger = ({
   ref,
   ...props
 }: TriggerComponentProps) => {
-  const { disabled, open, onOpenChange, nativeID } = useCollapsibleContext();
+  const { disabled, open, onOpenChange } = useCollapsibleContext();
 
   function onPress(ev: GestureResponderEvent) {
     if (disabled || disabledProp) return;
@@ -78,8 +76,8 @@ const Trigger = ({
   return (
     <Component
       ref={ref}
-      nativeID={nativeID}
       aria-disabled={(disabled || disabledProp) ?? undefined}
+      aria-expanded={open}
       role='button'
       onPress={onPress}
       accessibilityState={{
@@ -96,7 +94,7 @@ Trigger.displayName = 'TriggerNativeCollapsible';
 type ContentComponentProps = ContentProps & React.RefAttributes<ContentRef>;
 
 const Content = ({ asChild, forceMount, ref, ...props }: ContentComponentProps) => {
-  const { nativeID, open } = useCollapsibleContext();
+  const { open } = useCollapsibleContext();
 
   if (!forceMount) {
     if (!open) {
@@ -106,13 +104,7 @@ const Content = ({ asChild, forceMount, ref, ...props }: ContentComponentProps) 
 
   const Component = asChild ? Slot : View;
   return (
-    <Component
-      ref={ref}
-      aria-hidden={!(forceMount || open)}
-      aria-labelledby={nativeID}
-      role={'region'}
-      {...props}
-    />
+    <Component ref={ref} aria-hidden={!(forceMount || open)} role={'region'} {...props} />
   );
 };
 

--- a/packages/context-menu/package.json
+++ b/packages/context-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/context-menu",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive context menu",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/context-menu/src/context-menu.tsx
+++ b/packages/context-menu/src/context-menu.tsx
@@ -1,4 +1,5 @@
 import {
+  useAccessibilityFocus,
   useComposedRefs,
   useControllableState,
   useEffectEvent,
@@ -190,6 +191,7 @@ const Trigger = ({
       ref={composedRef}
       aria-disabled={disabled ?? undefined}
       role='button'
+      accessibilityState={{ disabled: disabled ?? false, expanded: open }}
       onLongPress={onLongPress}
       disabled={disabled ?? undefined}
       aria-expanded={open}
@@ -252,7 +254,7 @@ const Overlay = ({
   }
 
   const Component = asChild ? Slot : Pressable;
-  return <Component ref={ref} onPress={onPress} {...props} />;
+  return <Component ref={ref} accessible={false} onPress={onPress} {...props} />;
 };
 
 Overlay.displayName = 'OverlayNativeContextMenu';
@@ -277,11 +279,12 @@ const Content = ({
     open,
     onOpenChange,
     contentLayout,
-    nativeID,
     pressPosition,
     setContentLayout,
     setPressPosition,
   } = useRootContext();
+  const accessibilityFocusRef = useAccessibilityFocus<ContentRef>(open);
+  const composedRef = useComposedRefs(ref, accessibilityFocusRef);
 
   React.useEffect(() => {
     const backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
@@ -323,10 +326,14 @@ const Content = ({
   const Component = asChild ? Slot : View;
   return (
     <Component
-      ref={ref}
+      ref={composedRef}
       role='menu'
-      nativeID={nativeID}
       aria-modal={true}
+      onAccessibilityEscape={() => {
+        setPressPosition(null);
+        setContentLayout(null);
+        onOpenChange(false);
+      }}
       style={[positionStyle, style]}
       onLayout={onLayout}
       onStartShouldSetResponder={onStartShouldSetResponder}
@@ -365,7 +372,7 @@ const Item = ({
       role='menuitem'
       onPress={onPress}
       disabled={disabled}
-      aria-valuetext={textValue}
+      aria-label={textValue}
       aria-disabled={!!disabled}
       accessibilityState={{ disabled: !!disabled }}
       {...props}
@@ -412,7 +419,7 @@ const CheckboxItem = ({
   ref,
   ...props
 }: CheckboxItemComponentProps) => {
-  const { onOpenChange, setContentLayout, setPressPosition, nativeID } = useRootContext();
+  const { onOpenChange, setContentLayout, setPressPosition } = useRootContext();
 
   function onPress(ev: GestureResponderEvent) {
     onCheckedChange(!checked);
@@ -434,8 +441,8 @@ const CheckboxItem = ({
         onPress={onPress}
         disabled={disabled}
         aria-disabled={!!disabled}
-        aria-valuetext={textValue}
-        accessibilityState={{ disabled: !!disabled }}
+        aria-label={textValue}
+        accessibilityState={{ disabled: !!disabled, checked }}
         {...props}
       />
     </FormItemContext.Provider>
@@ -509,7 +516,7 @@ const RadioItem = ({
           disabled: disabled ?? false,
           checked: value === itemValue,
         }}
-        aria-valuetext={textValue}
+        aria-label={textValue}
         {...props}
       />
     </RadioItemContext.Provider>
@@ -550,7 +557,6 @@ const Separator = ({ asChild, decorative, ref, ...props }: SeparatorComponentPro
 Separator.displayName = 'SeparatorNativeContextMenu';
 
 const SubContext = React.createContext<{
-  nativeID: string;
   open: boolean;
   onOpenChange: (value: boolean) => void;
 } | null>(null);
@@ -564,7 +570,6 @@ const Sub = ({
   ref,
   ...props
 }: SubComponentProps) => {
-  const nativeID = React.useId();
   const [open = false, onOpenChange] = useControllableState({
     prop: openProp,
     defaultProp: defaultOpen,
@@ -575,7 +580,6 @@ const Sub = ({
   return (
     <SubContext.Provider
       value={{
-        nativeID,
         open,
         onOpenChange,
       }}
@@ -604,7 +608,7 @@ const SubTrigger = ({
   ref,
   ...props
 }: SubTriggerComponentProps) => {
-  const { nativeID, open, onOpenChange } = useSubContext();
+  const { open, onOpenChange } = useSubContext();
 
   function onPress(ev: GestureResponderEvent) {
     onOpenChange(!open);
@@ -615,11 +619,10 @@ const SubTrigger = ({
   return (
     <Component
       ref={ref}
-      aria-valuetext={textValue}
+      aria-label={textValue}
       role='menuitem'
       aria-expanded={open}
       accessibilityState={{ expanded: open, disabled: !!disabled }}
-      nativeID={nativeID}
       onPress={onPress}
       disabled={disabled}
       aria-disabled={!!disabled}
@@ -632,7 +635,9 @@ SubTrigger.displayName = 'SubTriggerNativeContextMenu';
 type SubContentComponentProps = SubContentProps & React.RefAttributes<SubContentRef>;
 
 const SubContent = ({ asChild = false, forceMount, ref, ...props }: SubContentComponentProps) => {
-  const { open, nativeID } = useSubContext();
+  const { open, onOpenChange } = useSubContext();
+  const accessibilityFocusRef = useAccessibilityFocus<SubContentRef>(open);
+  const composedRef = useComposedRefs(ref, accessibilityFocusRef);
 
   if (!forceMount) {
     if (!open) {
@@ -641,7 +646,15 @@ const SubContent = ({ asChild = false, forceMount, ref, ...props }: SubContentCo
   }
 
   const Component = asChild ? Slot : Pressable;
-  return <Component ref={ref} role='group' aria-labelledby={nativeID} {...props} />;
+  return (
+    <Component
+      ref={composedRef}
+      accessible={false}
+      role='menu'
+      onAccessibilityEscape={() => onOpenChange(false)}
+      {...props}
+    />
+  );
 };
 
 Content.displayName = 'ContentNativeContextMenu';

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/dialog",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive dialog",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/dialog/src/dialog.tsx
+++ b/packages/dialog/src/dialog.tsx
@@ -1,4 +1,8 @@
-import { useControllableState } from '@rn-primitives/hooks';
+import {
+  useAccessibilityFocus,
+  useComposedRefs,
+  useControllableState,
+} from '@rn-primitives/hooks';
 import { Portal as RNPPortal } from '@rn-primitives/portal';
 import { Slot } from '@rn-primitives/slot';
 import * as React from 'react';
@@ -86,7 +90,9 @@ const Trigger = ({
     <Component
       ref={ref}
       aria-disabled={disabled ?? undefined}
+      aria-expanded={open}
       role='button'
+      accessibilityState={{ disabled: disabled ?? false, expanded: open }}
       onPress={onPress}
       disabled={disabled ?? undefined}
       {...props}
@@ -140,14 +146,16 @@ const Overlay = ({
   }
 
   const Component = asChild ? Slot : Pressable;
-  return <Component ref={ref} onPress={onPress} {...props} />;
+  return <Component ref={ref} accessible={false} onPress={onPress} {...props} />;
 };
 
 Overlay.displayName = 'OverlayNativeDialog';
 type ContentComponentProps = ContentProps & React.RefAttributes<ContentRef>;
 
 const Content = ({ asChild, forceMount, ref, ...props }: ContentComponentProps) => {
-  const { open, nativeID, onOpenChange } = useRootContext();
+  const { open, onOpenChange } = useRootContext();
+  const accessibilityFocusRef = useAccessibilityFocus<ContentRef>(open);
+  const composedRef = useComposedRefs(ref, accessibilityFocusRef);
 
   React.useEffect(() => {
     const backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
@@ -169,12 +177,10 @@ const Content = ({ asChild, forceMount, ref, ...props }: ContentComponentProps) 
   const Component = asChild ? Slot : View;
   return (
     <Component
-      ref={ref}
+      ref={composedRef}
       role='dialog'
-      nativeID={nativeID}
-      aria-labelledby={`${nativeID}_label`}
-      aria-describedby={`${nativeID}_desc`}
       aria-modal={true}
+      onAccessibilityEscape={() => onOpenChange(false)}
       onStartShouldSetResponder={onStartShouldSetResponder}
       {...props}
     />
@@ -216,16 +222,14 @@ Close.displayName = 'CloseNativeDialog';
 type TitleComponentProps = TitleProps & React.RefAttributes<TitleRef>;
 
 const Title = ({ ref, ...props }: TitleComponentProps) => {
-  const { nativeID } = useRootContext();
-  return <Text ref={ref} role='heading' nativeID={`${nativeID}_label`} {...props} />;
+  return <Text ref={ref} role='heading' {...props} />;
 };
 
 Title.displayName = 'TitleNativeDialog';
 type DescriptionComponentProps = DescriptionProps & React.RefAttributes<DescriptionRef>;
 
 const Description = ({ ref, ...props }: DescriptionComponentProps) => {
-  const { nativeID } = useRootContext();
-  return <Text ref={ref} nativeID={`${nativeID}_desc`} {...props} />;
+  return <Text ref={ref} {...props} />;
 };
 
 Description.displayName = 'DescriptionNativeDialog';

--- a/packages/dropdown-menu/package.json
+++ b/packages/dropdown-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/dropdown-menu",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive dropdown menu",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/dropdown-menu/src/dropdown-menu.tsx
+++ b/packages/dropdown-menu/src/dropdown-menu.tsx
@@ -1,4 +1,5 @@
 import {
+  useAccessibilityFocus,
   useComposedRefs,
   useControllableState,
   useEffectEvent,
@@ -159,6 +160,7 @@ const Trigger = ({
       ref={composedRef}
       aria-disabled={disabled ?? undefined}
       role='button'
+      accessibilityState={{ disabled: disabled ?? false, expanded: open }}
       onPress={onPress}
       disabled={disabled ?? undefined}
       aria-expanded={open}
@@ -219,7 +221,7 @@ const Overlay = ({
   }
 
   const Component = asChild ? Slot : Pressable;
-  return <Component ref={ref} onPress={onPress} {...props} />;
+  return <Component ref={ref} accessible={false} onPress={onPress} {...props} />;
 };
 
 Overlay.displayName = 'OverlayNativeDropdownMenu';
@@ -243,12 +245,13 @@ const Content = ({
   const {
     open,
     onOpenChange,
-    nativeID,
     triggerPosition,
     setTriggerPosition,
     contentLayout,
     setContentLayout,
   } = useRootContext();
+  const accessibilityFocusRef = useAccessibilityFocus<ContentRef>(open);
+  const composedRef = useComposedRefs(ref, accessibilityFocusRef);
 
   React.useEffect(() => {
     const backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
@@ -290,10 +293,15 @@ const Content = ({
   const Component = asChild ? Slot : Pressable;
   return (
     <Component
-      ref={ref}
+      ref={composedRef}
+      accessible={false}
       role='menu'
-      nativeID={nativeID}
       aria-modal={true}
+      onAccessibilityEscape={() => {
+        setTriggerPosition(null);
+        setContentLayout(null);
+        onOpenChange(false);
+      }}
       style={[positionStyle, style]}
       onLayout={onLayout}
       {...props}
@@ -331,7 +339,7 @@ const Item = ({
       role='menuitem'
       onPress={onPress}
       disabled={disabled}
-      aria-valuetext={textValue}
+      aria-label={textValue}
       aria-disabled={!!disabled}
       accessibilityState={{ disabled: !!disabled }}
       {...props}
@@ -378,7 +386,7 @@ const CheckboxItem = ({
   ref,
   ...props
 }: CheckboxItemComponentProps) => {
-  const { onOpenChange, setContentLayout, setTriggerPosition, nativeID } = useRootContext();
+  const { onOpenChange, setContentLayout, setTriggerPosition } = useRootContext();
 
   function onPress(ev: GestureResponderEvent) {
     onCheckedChange(!checked);
@@ -400,8 +408,8 @@ const CheckboxItem = ({
         onPress={onPress}
         disabled={disabled}
         aria-disabled={!!disabled}
-        aria-valuetext={textValue}
-        accessibilityState={{ disabled: !!disabled }}
+        aria-label={textValue}
+        accessibilityState={{ disabled: !!disabled, checked }}
         {...props}
       />
     </FormItemContext.Provider>
@@ -475,7 +483,7 @@ const RadioItem = ({
           disabled: disabled ?? false,
           checked: value === itemValue,
         }}
-        aria-valuetext={textValue}
+        aria-label={textValue}
         {...props}
       />
     </RadioItemContext.Provider>
@@ -516,7 +524,6 @@ const Separator = ({ asChild, decorative, ref, ...props }: SeparatorComponentPro
 Separator.displayName = 'SeparatorNativeDropdownMenu';
 
 const SubContext = React.createContext<{
-  nativeID: string;
   open: boolean;
   onOpenChange: (value: boolean) => void;
 } | null>(null);
@@ -530,7 +537,6 @@ const Sub = ({
   ref,
   ...props
 }: SubComponentProps) => {
-  const nativeID = React.useId();
   const [open = false, onOpenChange] = useControllableState({
     prop: openProp,
     defaultProp: defaultOpen,
@@ -541,7 +547,6 @@ const Sub = ({
   return (
     <SubContext.Provider
       value={{
-        nativeID,
         open,
         onOpenChange,
       }}
@@ -570,7 +575,7 @@ const SubTrigger = ({
   ref,
   ...props
 }: SubTriggerComponentProps) => {
-  const { nativeID, open, onOpenChange } = useSubContext();
+  const { open, onOpenChange } = useSubContext();
 
   function onPress(ev: GestureResponderEvent) {
     onOpenChange(!open);
@@ -581,11 +586,10 @@ const SubTrigger = ({
   return (
     <Component
       ref={ref}
-      aria-valuetext={textValue}
+      aria-label={textValue}
       role='menuitem'
       aria-expanded={open}
       accessibilityState={{ expanded: open, disabled: !!disabled }}
-      nativeID={nativeID}
       onPress={onPress}
       disabled={disabled}
       aria-disabled={!!disabled}
@@ -598,7 +602,9 @@ SubTrigger.displayName = 'SubTriggerNativeDropdownMenu';
 type SubContentComponentProps = SubContentProps & React.RefAttributes<SubContentRef>;
 
 const SubContent = ({ asChild = false, forceMount, ref, ...props }: SubContentComponentProps) => {
-  const { open, nativeID } = useSubContext();
+  const { open, onOpenChange } = useSubContext();
+  const accessibilityFocusRef = useAccessibilityFocus<SubContentRef>(open);
+  const composedRef = useComposedRefs(ref, accessibilityFocusRef);
 
   if (!forceMount) {
     if (!open) {
@@ -607,7 +613,15 @@ const SubContent = ({ asChild = false, forceMount, ref, ...props }: SubContentCo
   }
 
   const Component = asChild ? Slot : Pressable;
-  return <Component ref={ref} role='group' aria-labelledby={nativeID} {...props} />;
+  return (
+    <Component
+      ref={composedRef}
+      accessible={false}
+      role='menu'
+      onAccessibilityEscape={() => onOpenChange(false)}
+      {...props}
+    />
+  );
 };
 
 Content.displayName = 'ContentNativeDropdownMenu';

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/hooks",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive hooks",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,3 +1,4 @@
+export { useAccessibilityFocus } from './useAccessibilityFocus';
 export { useAugmentedRef } from './useAugmentedRef';
 export { useRelativePosition, type LayoutPosition } from './useRelativePosition';
 export { useControllableState } from './useControllableState';

--- a/packages/hooks/src/useAccessibilityFocus.tsx
+++ b/packages/hooks/src/useAccessibilityFocus.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { AccessibilityInfo, findNodeHandle } from 'react-native';
+
+/**
+ * Moves screen reader (VoiceOver/TalkBack) focus to the attached element when `enabled`
+ * becomes true. No-op when no screen reader is running.
+ *
+ * Attach the returned ref to the container of the content that should receive focus
+ * (e.g. an opened dialog, menu, or popover content). The target must NOT be
+ * `accessible={true}` — collapsing the container into a single accessibility element
+ * would make its children unselectable by the screen reader. When the target is a
+ * plain (non-accessible) container, focus lands on its first accessible descendant.
+ */
+export function useAccessibilityFocus<T>(enabled: boolean = true) {
+  const ref = React.useRef<T>(null);
+
+  React.useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    // Small delay so the view is mounted and mounting animations have started;
+    // setting focus synchronously on mount is unreliable on both platforms.
+    const timeout = setTimeout(() => {
+      const node = findNodeHandle(ref.current as React.Component | null);
+      if (node != null) {
+        AccessibilityInfo.setAccessibilityFocus(node);
+      }
+    }, 50);
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [enabled]);
+
+  return ref;
+}

--- a/packages/hover-card/package.json
+++ b/packages/hover-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/hover-card",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive hover card",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/hover-card/src/hover-card.tsx
+++ b/packages/hover-card/src/hover-card.tsx
@@ -1,4 +1,5 @@
 import {
+  useAccessibilityFocus,
   useComposedRefs,
   useEffectEvent,
   useRelativePosition,
@@ -137,7 +138,9 @@ const Trigger = ({
     <Component
       ref={composedRef}
       aria-disabled={disabled ?? undefined}
+      aria-expanded={open}
       role='button'
+      accessibilityState={{ disabled: disabled ?? false, expanded: open }}
       onPress={onPress}
       disabled={disabled ?? undefined}
       {...props}
@@ -197,7 +200,7 @@ const Overlay = ({
   }
 
   const Component = asChild ? Slot : Pressable;
-  return <Component ref={ref} onPress={onPress} {...props} />;
+  return <Component ref={ref} accessible={false} onPress={onPress} {...props} />;
 };
 
 Overlay.displayName = 'OverlayNativeHoverCard';
@@ -222,11 +225,12 @@ const Content = ({
     open,
     onOpenChange,
     contentLayout,
-    nativeID,
     setContentLayout,
     setTriggerPosition,
     triggerPosition,
   } = useRootContext();
+  const accessibilityFocusRef = useAccessibilityFocus<ContentRef>(open);
+  const composedContentRef = useComposedRefs(ref, accessibilityFocusRef);
 
   React.useEffect(() => {
     const backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
@@ -268,10 +272,14 @@ const Content = ({
   const Component = asChild ? Slot : View;
   return (
     <Component
-      ref={ref}
+      ref={composedContentRef}
       role='dialog'
-      nativeID={nativeID}
       aria-modal={true}
+      onAccessibilityEscape={() => {
+        setTriggerPosition(null);
+        setContentLayout(null);
+        onOpenChange(false);
+      }}
       style={[positionStyle, style]}
       onLayout={onLayout}
       onStartShouldSetResponder={onStartShouldSetResponder}

--- a/packages/label/package.json
+++ b/packages/label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/label",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive label",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/menubar/package.json
+++ b/packages/menubar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/menubar",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive menubar",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/menubar/src/menubar.tsx
+++ b/packages/menubar/src/menubar.tsx
@@ -1,4 +1,5 @@
 import {
+  useAccessibilityFocus,
   useComposedRefs,
   useControllableState,
   useRelativePosition,
@@ -81,7 +82,7 @@ const Root = ({ asChild, value, onValueChange, ref, ...viewProps }: RootComponen
         triggerPosition,
       }}
     >
-      <Component ref={ref} {...viewProps} />
+      <Component ref={ref} role='menubar' {...viewProps} />
     </RootContext.Provider>
   );
 };
@@ -107,7 +108,7 @@ const Menu = ({ asChild, value, ref, ...viewProps }: MenuComponentProps) => {
         value,
       }}
     >
-      <Component ref={ref} role='menubar' {...viewProps} />
+      <Component ref={ref} role='group' {...viewProps} />
     </MenuContext.Provider>
   );
 };
@@ -151,6 +152,7 @@ const Trigger = ({
       ref={composedRef}
       aria-disabled={disabled ?? undefined}
       role='button'
+      accessibilityState={{ disabled: disabled ?? false, expanded: value === menuValue }}
       onPress={onPress}
       disabled={disabled ?? undefined}
       aria-expanded={value === menuValue}
@@ -216,7 +218,7 @@ const Overlay = ({
   }
 
   const Component = asChild ? Slot : Pressable;
-  return <Component ref={ref} onPress={onPress} {...props} />;
+  return <Component ref={ref} accessible={false} onPress={onPress} {...props} />;
 };
 
 Overlay.displayName = 'OverlayMenubar';
@@ -243,10 +245,11 @@ const Content = ({
     triggerPosition,
     contentLayout,
     setContentLayout,
-    nativeID,
     setTriggerPosition,
   } = useRootContext();
   const { value: menuValue } = useMenuContext();
+  const accessibilityFocusRef = useAccessibilityFocus<ContentRef>(value === menuValue);
+  const composedRef = useComposedRefs(ref, accessibilityFocusRef);
 
   React.useEffect(() => {
     const backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
@@ -288,10 +291,14 @@ const Content = ({
   const Component = asChild ? Slot : View;
   return (
     <Component
-      ref={ref}
+      ref={composedRef}
       role='menu'
-      nativeID={nativeID}
       aria-modal={true}
+      onAccessibilityEscape={() => {
+        setTriggerPosition(null);
+        setContentLayout(null);
+        onValueChange(undefined);
+      }}
       style={[positionStyle, style]}
       onLayout={onLayout}
       onStartShouldSetResponder={onStartShouldSetResponder}
@@ -330,7 +337,7 @@ const Item = ({
       role='menuitem'
       onPress={onPress}
       disabled={disabled}
-      aria-valuetext={textValue}
+      aria-label={textValue}
       aria-disabled={!!disabled}
       accessibilityState={{ disabled: !!disabled }}
       {...props}
@@ -377,7 +384,7 @@ const CheckboxItem = ({
   ref,
   ...props
 }: CheckboxItemComponentProps) => {
-  const { onValueChange, setTriggerPosition, setContentLayout, nativeID } = useRootContext();
+  const { onValueChange, setTriggerPosition, setContentLayout } = useRootContext();
 
   function onPress(ev: GestureResponderEvent) {
     onCheckedChange(!checked);
@@ -399,8 +406,8 @@ const CheckboxItem = ({
         onPress={onPress}
         disabled={disabled}
         aria-disabled={!!disabled}
-        aria-valuetext={textValue}
-        accessibilityState={{ disabled: !!disabled }}
+        aria-label={textValue}
+        accessibilityState={{ disabled: !!disabled, checked }}
         {...props}
       />
     </FormItemContext.Provider>
@@ -478,7 +485,7 @@ const RadioItem = ({
           disabled: disabled ?? false,
           checked: value === itemValue,
         }}
-        aria-valuetext={textValue}
+        aria-label={textValue}
         {...props}
       />
     </RadioItemContext.Provider>
@@ -519,7 +526,6 @@ const Separator = ({ asChild, decorative, ref, ...props }: SeparatorComponentPro
 Separator.displayName = 'SeparatorMenubar';
 
 const SubContext = React.createContext<{
-  nativeID: string;
   open: boolean;
   onOpenChange: (value: boolean) => void;
 } | null>(null);
@@ -533,7 +539,6 @@ const Sub = ({
   ref,
   ...props
 }: SubComponentProps) => {
-  const nativeID = React.useId();
   const [open = false, onOpenChange] = useControllableState({
     prop: openProp,
     defaultProp: defaultOpen,
@@ -544,7 +549,6 @@ const Sub = ({
   return (
     <SubContext.Provider
       value={{
-        nativeID,
         open,
         onOpenChange,
       }}
@@ -573,7 +577,7 @@ const SubTrigger = ({
   ref,
   ...props
 }: SubTriggerComponentProps) => {
-  const { nativeID, open, onOpenChange } = useSubContext();
+  const { open, onOpenChange } = useSubContext();
 
   function onPress(ev: GestureResponderEvent) {
     onOpenChange(!open);
@@ -584,11 +588,10 @@ const SubTrigger = ({
   return (
     <Component
       ref={ref}
-      aria-valuetext={textValue}
+      aria-label={textValue}
       role='menuitem'
       aria-expanded={open}
       accessibilityState={{ expanded: open, disabled: !!disabled }}
-      nativeID={nativeID}
       onPress={onPress}
       disabled={disabled}
       aria-disabled={!!disabled}
@@ -601,7 +604,9 @@ SubTrigger.displayName = 'SubTriggerMenubar';
 type SubContentComponentProps = SubContentProps & React.RefAttributes<SubContentRef>;
 
 const SubContent = ({ asChild = false, forceMount, ref, ...props }: SubContentComponentProps) => {
-  const { open, nativeID } = useSubContext();
+  const { open, onOpenChange } = useSubContext();
+  const accessibilityFocusRef = useAccessibilityFocus<SubContentRef>(open);
+  const composedRef = useComposedRefs(ref, accessibilityFocusRef);
 
   if (!forceMount) {
     if (!open) {
@@ -610,7 +615,14 @@ const SubContent = ({ asChild = false, forceMount, ref, ...props }: SubContentCo
   }
 
   const Component = asChild ? Slot : View;
-  return <Component ref={ref} role='group' aria-labelledby={nativeID} {...props} />;
+  return (
+    <Component
+      ref={composedRef}
+      role='menu'
+      onAccessibilityEscape={() => onOpenChange(false)}
+      {...props}
+    />
+  );
 };
 
 SubContent.displayName = 'SubContentMenubar';

--- a/packages/navigation-menu/package.json
+++ b/packages/navigation-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/navigation-menu",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive navigation menu",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/navigation-menu/src/navigation-menu.tsx
+++ b/packages/navigation-menu/src/navigation-menu.tsx
@@ -1,4 +1,9 @@
-import { useComposedRefs, useRelativePosition, type LayoutPosition } from '@rn-primitives/hooks';
+import {
+  useAccessibilityFocus,
+  useComposedRefs,
+  useRelativePosition,
+  type LayoutPosition,
+} from '@rn-primitives/hooks';
 import { Portal as RNPPortal } from '@rn-primitives/portal';
 import { Slot } from '@rn-primitives/slot';
 import * as React from 'react';
@@ -79,26 +84,23 @@ type ListComponentProps = ListProps & React.RefAttributes<ListRef>;
 
 const List = ({ asChild, ref, ...viewProps }: ListComponentProps) => {
   const Component = asChild ? Slot : View;
-  return <Component ref={ref} role='menubar' {...viewProps} />;
+  return <Component ref={ref} role='list' {...viewProps} />;
 };
 
 List.displayName = 'ListNativeNavigationMenu';
 
-const ItemContext = React.createContext<(ItemProps & { nativeID: string }) | null>(null);
+const ItemContext = React.createContext<ItemProps | null>(null);
 type ItemComponentProps = ItemProps & React.RefAttributes<ItemRef>;
 
 const Item = ({ asChild, value, ref, ...viewProps }: ItemComponentProps) => {
-  const nativeID = React.useId();
-
   const Component = asChild ? Slot : View;
   return (
     <ItemContext.Provider
       value={{
         value,
-        nativeID,
       }}
     >
-      <Component ref={ref} role='menuitem' {...viewProps} />
+      <Component ref={ref} role='listitem' {...viewProps} />
     </ItemContext.Provider>
   );
 };
@@ -144,6 +146,7 @@ const Trigger = ({
       ref={composedRef}
       aria-disabled={disabled ?? undefined}
       role='button'
+      accessibilityState={{ disabled: disabled ?? false, expanded: value === menuValue }}
       onPress={onPress}
       disabled={disabled ?? undefined}
       aria-expanded={value === menuValue}
@@ -207,7 +210,9 @@ const Content = ({
     contentLayout,
     setContentLayout,
   } = useRootContext();
-  const { value: menuValue, nativeID } = useItemContext();
+  const { value: menuValue } = useItemContext();
+  const accessibilityFocusRef = useAccessibilityFocus<ContentRef>(value === menuValue);
+  const composedRef = useComposedRefs(ref, accessibilityFocusRef);
 
   React.useEffect(() => {
     const backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
@@ -249,10 +254,13 @@ const Content = ({
   const Component = asChild ? Slot : View;
   return (
     <Component
-      ref={ref}
-      role='menu'
-      nativeID={nativeID}
-      aria-modal={true}
+      ref={composedRef}
+      role='group'
+      onAccessibilityEscape={() => {
+        setTriggerPosition(null);
+        setContentLayout(null);
+        onValueChange('');
+      }}
       style={[positionStyle, style]}
       onLayout={onLayout}
       onStartShouldSetResponder={onStartShouldSetResponder}
@@ -281,7 +289,7 @@ type IndicatorComponentProps = IndicatorProps & React.RefAttributes<IndicatorRef
 
 const Indicator = ({ asChild, ref, ...props }: IndicatorComponentProps) => {
   const Component = asChild ? Slot : View;
-  return <Component ref={ref} {...props} />;
+  return <Component ref={ref} role='presentation' aria-hidden={true} {...props} />;
 };
 
 Indicator.displayName = 'IndicatorNativeNavigationMenu';

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/popover",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive popover",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/popover/src/popover.tsx
+++ b/packages/popover/src/popover.tsx
@@ -1,4 +1,5 @@
 import {
+  useAccessibilityFocus,
   useComposedRefs,
   useEffectEvent,
   useRelativePosition,
@@ -133,7 +134,9 @@ const Trigger = ({
     <Component
       ref={composedRef}
       aria-disabled={disabled ?? undefined}
+      aria-expanded={open}
       role='button'
+      accessibilityState={{ disabled: disabled ?? false, expanded: open }}
       onPress={onPress}
       disabled={disabled ?? undefined}
       {...props}
@@ -193,7 +196,7 @@ const Overlay = ({
   }
 
   const Component = asChild ? Slot : Pressable;
-  return <Component ref={ref} onPress={onPress} {...props} />;
+  return <Component ref={ref} accessible={false} onPress={onPress} {...props} />;
 };
 
 Overlay.displayName = 'OverlayNativePopover';
@@ -219,11 +222,12 @@ const Content = ({
     open,
     onOpenChange,
     contentLayout,
-    nativeID,
     setContentLayout,
     setTriggerPosition,
     triggerPosition,
   } = useRootContext();
+  const accessibilityFocusRef = useAccessibilityFocus<ContentRef>(open);
+  const composedRef = useComposedRefs(ref, accessibilityFocusRef);
 
   React.useEffect(() => {
     const backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
@@ -265,10 +269,14 @@ const Content = ({
   const Component = asChild ? Slot : View;
   return (
     <Component
-      ref={ref}
+      ref={composedRef}
       role='dialog'
-      nativeID={nativeID}
       aria-modal={true}
+      onAccessibilityEscape={() => {
+        setTriggerPosition(null);
+        setContentLayout(null);
+        onOpenChange(false);
+      }}
       style={[positionStyle, style]}
       onLayout={onLayout}
       onStartShouldSetResponder={onStartShouldSetResponder}

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/portal",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive portal",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/progress/package.json
+++ b/packages/progress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/progress",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive progress",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/progress/src/progress.tsx
+++ b/packages/progress/src/progress.tsx
@@ -26,6 +26,7 @@ const Root = ({
     <Component
       role='progressbar'
       ref={ref}
+      accessible={true}
       aria-valuemax={max}
       aria-valuemin={0}
       aria-valuenow={value}

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/radio-group",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive radio group",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/select",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive select",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/select/src/select.tsx
+++ b/packages/select/src/select.tsx
@@ -1,4 +1,5 @@
 import {
+  useAccessibilityFocus,
   useComposedRefs,
   useControllableState,
   useEffectEvent,
@@ -165,6 +166,7 @@ const Trigger = ({
       ref={composedRef}
       aria-disabled={disabled ?? undefined}
       role='combobox'
+      accessibilityState={{ disabled: (disabled || disabledRoot) ?? false, expanded: open }}
       onPress={onPress}
       disabled={disabled ?? disabledRoot}
       aria-expanded={open}
@@ -238,7 +240,7 @@ const Overlay = ({
   }
 
   const Component = asChild ? Slot : Pressable;
-  return <Component ref={ref} onPress={onPress} {...props} />;
+  return <Component ref={ref} accessible={false} onPress={onPress} {...props} />;
 };
 
 Overlay.displayName = 'OverlayNativeSelect';
@@ -264,11 +266,12 @@ const Content = ({
     open,
     onOpenChange,
     contentLayout,
-    nativeID,
     triggerPosition,
     setContentLayout,
     setTriggerPosition,
   } = useRootContext();
+  const accessibilityFocusRef = useAccessibilityFocus<ContentRef>(open);
+  const composedRef = useComposedRefs(ref, accessibilityFocusRef);
 
   React.useEffect(() => {
     const backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
@@ -310,10 +313,14 @@ const Content = ({
   const Component = asChild ? Slot : View;
   return (
     <Component
-      ref={ref}
+      ref={composedRef}
       role='list'
-      nativeID={nativeID}
       aria-modal={true}
+      onAccessibilityEscape={() => {
+        setTriggerPosition(null);
+        setContentLayout(null);
+        onOpenChange(false);
+      }}
       style={[positionStyle, style]}
       onLayout={onLayout}
       onStartShouldSetResponder={onStartShouldSetResponder}
@@ -361,12 +368,12 @@ const Item = ({
         role='option'
         onPress={onPress}
         disabled={disabled}
-        aria-checked={value?.value === itemValue}
-        aria-valuetext={label}
+        aria-selected={value?.value === itemValue}
+        aria-label={label}
         aria-disabled={!!disabled}
         accessibilityState={{
           disabled: !!disabled,
-          checked: value?.value === itemValue,
+          selected: value?.value === itemValue,
         }}
         {...props}
       />

--- a/packages/separator/package.json
+++ b/packages/separator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/separator",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive separator",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/separator/src/separator.tsx
+++ b/packages/separator/src/separator.tsx
@@ -15,6 +15,7 @@ const Root = ({
   return (
     <Component
       role={decorative ? 'presentation' : 'separator'}
+      aria-hidden={!!decorative}
       aria-orientation={orientation}
       ref={ref}
       {...props}

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/slider",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive slider",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/slider/src/slider.tsx
+++ b/packages/slider/src/slider.tsx
@@ -1,6 +1,6 @@
 import { Slot } from '@rn-primitives/slot';
 import * as React from 'react';
-import { View } from 'react-native';
+import { View, type AccessibilityActionEvent } from 'react-native';
 import type {
   RangeProps,
   RangeRef,
@@ -23,14 +23,14 @@ const Root = ({
   max,
   dir: _dir,
   inverted: _inverted,
-  step: _step,
-  onValueChange: _onValueChange,
+  step,
+  onValueChange,
   ref,
   ...props
 }: RootComponentProps) => {
   const Component = asChild ? Slot : View;
   return (
-    <RootContext.Provider value={{ value, disabled, min, max }}>
+    <RootContext.Provider value={{ value, disabled, min, max, step, onValueChange }}>
       <Component ref={ref} role='group' {...props} />
     </RootContext.Provider>
   );
@@ -45,21 +45,44 @@ function useSliderContext() {
   }
   return context;
 }
+
+const accessibilityActions = [{ name: 'increment' }, { name: 'decrement' }];
 type TrackComponentProps = TrackProps & React.RefAttributes<TrackRef>;
 
-const Track = ({ asChild, ref, ...props }: TrackComponentProps) => {
-  const { value, min, max, disabled } = useSliderContext();
+const Track = ({
+  asChild,
+  onAccessibilityAction: onAccessibilityActionProp,
+  ref,
+  ...props
+}: TrackComponentProps) => {
+  const { value, min, max, disabled, step, onValueChange } = useSliderContext();
+
+  function onAccessibilityAction(event: AccessibilityActionEvent) {
+    if (disabled) return;
+    const delta = step ?? 1;
+    if (event.nativeEvent.actionName === 'increment') {
+      onValueChange?.([Math.min(max ?? 100, value + delta)]);
+    }
+    if (event.nativeEvent.actionName === 'decrement') {
+      onValueChange?.([Math.max(min ?? 0, value - delta)]);
+    }
+    onAccessibilityActionProp?.(event);
+  }
 
   const Component = asChild ? Slot : View;
   return (
     <Component
       ref={ref}
+      accessible={true}
       aria-disabled={disabled}
       role='slider'
       aria-valuemin={min}
       aria-valuemax={max}
       aria-valuenow={value}
       accessibilityValue={{ max, min, now: value }}
+      accessibilityState={{ disabled: disabled ?? false }}
+      accessibilityActions={accessibilityActions}
+      onAccessibilityAction={onAccessibilityAction}
       {...props}
     />
   );
@@ -78,7 +101,7 @@ type ThumbComponentProps = ThumbProps & React.RefAttributes<ThumbRef>;
 
 const Thumb = ({ asChild, ref, ...props }: ThumbComponentProps) => {
   const Component = asChild ? Slot : View;
-  return <Component accessibilityRole='adjustable' ref={ref} {...props} />;
+  return <Component ref={ref} role='presentation' {...props} />;
 };
 
 Thumb.displayName = 'ThumbNativeSlider';

--- a/packages/slider/src/types.ts
+++ b/packages/slider/src/types.ts
@@ -14,11 +14,11 @@ type RootProps = SlottableViewProps & {
    */
   inverted?: boolean;
   /**
-   * Platform: WEB ONLY
+   * On native, used as the increment/decrement amount for screen reader adjustments.
    */
   step?: number;
   /**
-   * Platform: WEB ONLY
+   * On native, called when a screen reader performs an increment/decrement action.
    */
   onValueChange?: (value: number[]) => void;
 };

--- a/packages/slot/package.json
+++ b/packages/slot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/slot",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive slot",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/switch",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive switch",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/switch/src/switch.tsx
+++ b/packages/switch/src/switch.tsx
@@ -27,7 +27,7 @@ const Root = ({
       aria-disabled={disabled}
       role='switch'
       aria-checked={checked}
-      aria-valuetext={ariaValueText ?? checked ? 'on' : 'off'}
+      aria-valuetext={ariaValueText ?? (checked ? 'on' : 'off')}
       onPress={onPress}
       accessibilityState={{
         checked,

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/table",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive table",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -24,7 +24,7 @@ type HeaderComponentProps = HeaderProps & React.RefAttributes<HeaderRef>;
 
 const Header = ({ asChild, ref, ...props }: HeaderComponentProps) => {
   const Component = asChild ? Slot : View;
-  return <Component role='rowheader' ref={ref} {...props} />;
+  return <Component role='rowgroup' ref={ref} {...props} />;
 };
 Header.displayName = 'HeaderTable';
 

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/tabs",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive tabs",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/tabs/src/tabs.tsx
+++ b/packages/tabs/src/tabs.tsx
@@ -12,11 +12,7 @@ import type {
   TriggerRef,
 } from './types';
 
-interface RootContext extends RootProps {
-  nativeID: string;
-}
-
-const TabsContext = React.createContext<RootContext | null>(null);
+const TabsContext = React.createContext<RootProps | null>(null);
 type RootComponentProps = RootProps & React.RefAttributes<RootRef>;
 
 const Root = ({
@@ -29,14 +25,12 @@ const Root = ({
   ref,
   ...viewProps
 }: RootComponentProps) => {
-  const nativeID = React.useId();
   const Component = asChild ? Slot : View;
   return (
     <TabsContext.Provider
       value={{
         value,
         onValueChange,
-        nativeID,
       }}
     >
       <Component ref={ref} {...viewProps} />
@@ -73,7 +67,7 @@ const Trigger = ({
   ref,
   ...props
 }: TriggerComponentProps) => {
-  const { onValueChange, value: rootValue, nativeID } = useRootContext();
+  const { onValueChange, value: rootValue } = useRootContext();
 
   function onPress(ev: GestureResponderEvent) {
     if (disabled) return;
@@ -86,7 +80,6 @@ const Trigger = ({
     <TriggerContext.Provider value={{ value: tabValue }}>
       <Component
         ref={ref}
-        nativeID={`${nativeID}-tab-${tabValue}`}
         aria-disabled={!!disabled}
         aria-selected={rootValue === tabValue}
         role='tab'
@@ -122,7 +115,7 @@ const Content = ({
   ref,
   ...props
 }: ContentComponentProps) => {
-  const { value: rootValue, nativeID } = useRootContext();
+  const { value: rootValue } = useRootContext();
 
   if (!forceMount) {
     if (rootValue !== tabValue) {
@@ -135,7 +128,6 @@ const Content = ({
     <Component
       ref={ref}
       aria-hidden={!(forceMount || rootValue === tabValue)}
-      aria-labelledby={`${nativeID}-tab-${tabValue}`}
       role='tabpanel'
       {...props}
     />

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -32,6 +32,7 @@
     "pub:release": "pnpm publish --access public"
   },
   "dependencies": {
+    "@rn-primitives/hooks": "workspace:*",
     "@rn-primitives/slot": "workspace:*",
     "@rn-primitives/types": "workspace:*"
   },

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/toast",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive toast",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/toast/src/toast.tsx
+++ b/packages/toast/src/toast.tsx
@@ -1,3 +1,4 @@
+import { useAccessibilityFocus, useComposedRefs } from '@rn-primitives/hooks';
 import { Slot } from '@rn-primitives/slot';
 import * as React from 'react';
 import { Pressable, Text, View, type GestureResponderEvent } from 'react-native';
@@ -14,10 +15,7 @@ import type {
   TitleRef,
 } from './types';
 
-interface RootContext extends RootProps {
-  nativeID: string;
-}
-const ToastContext = React.createContext<RootContext | null>(null);
+const ToastContext = React.createContext<RootProps | null>(null);
 type RootComponentProps = RootProps & React.RefAttributes<RootRef>;
 
 const Root = ({
@@ -28,7 +26,8 @@ const Root = ({
   ref,
   ...viewProps
 }: RootComponentProps) => {
-  const nativeID = React.useId();
+  const accessibilityFocusRef = useAccessibilityFocus<RootRef>(open && type === 'foreground');
+  const composedRef = useComposedRefs(ref, accessibilityFocusRef);
 
   if (!open) {
     return null;
@@ -41,12 +40,11 @@ const Root = ({
         open,
         onOpenChange,
         type,
-        nativeID,
       }}
     >
       <Component
-        ref={ref}
-        role='status'
+        ref={composedRef}
+        role={type === 'foreground' ? 'alert' : 'status'}
         aria-live={type === 'foreground' ? 'assertive' : 'polite'}
         {...viewProps}
       />
@@ -128,20 +126,16 @@ Action.displayName = 'ActionToast';
 type TitleComponentProps = TitleProps & React.RefAttributes<TitleRef>;
 
 const Title = ({ asChild, ref, ...props }: TitleComponentProps) => {
-  const { nativeID } = useToastContext();
-
   const Component = asChild ? Slot : Text;
-  return <Component ref={ref} role='heading' nativeID={`${nativeID}_label`} {...props} />;
+  return <Component ref={ref} role='heading' {...props} />;
 };
 
 Title.displayName = 'TitleToast';
 type DescriptionComponentProps = DescriptionProps & React.RefAttributes<DescriptionRef>;
 
 const Description = ({ asChild, ref, ...props }: DescriptionComponentProps) => {
-  const { nativeID } = useToastContext();
-
   const Component = asChild ? Slot : Text;
-  return <Component ref={ref} nativeID={`${nativeID}_desc`} {...props} />;
+  return <Component ref={ref} {...props} />;
 };
 
 Description.displayName = 'DescriptionToast';

--- a/packages/toggle-group/package.json
+++ b/packages/toggle-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/toggle-group",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive toggle group",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/toggle-group/src/toggle-group.tsx
+++ b/packages/toggle-group/src/toggle-group.tsx
@@ -32,7 +32,7 @@ const Root = ({
         } as RootProps
       }
     >
-      <Component ref={ref} role='group' {...viewProps} />
+      <Component ref={ref} role={type === 'single' ? 'radiogroup' : 'group'} {...viewProps} />
     </ToggleGroupContext.Provider>
   );
 };
@@ -60,7 +60,6 @@ const Item = ({
   ref,
   ...props
 }: ItemComponentProps) => {
-  const id = React.useId();
   const { type, disabled, value, onValueChange } = useRootContext();
 
   function onPress(ev: GestureResponderEvent) {
@@ -74,10 +73,7 @@ const Item = ({
     onPressProp?.(ev);
   }
 
-  const isChecked =
-    type === 'single' ? ToggleGroupUtils.getIsSelected(value, itemValue) : undefined;
-  const isSelected =
-    type === 'multiple' ? ToggleGroupUtils.getIsSelected(value, itemValue) : undefined;
+  const isSelected = ToggleGroupUtils.getIsSelected(value, itemValue);
 
   const Component = asChild ? Slot : Pressable;
   return (
@@ -87,13 +83,11 @@ const Item = ({
         aria-disabled={disabled}
         role={type === 'single' ? 'radio' : 'checkbox'}
         onPress={onPress}
-        aria-checked={isChecked}
-        aria-selected={isSelected}
+        aria-checked={isSelected}
         disabled={(disabled || disabledProp) ?? false}
         accessibilityState={{
           disabled: (disabled || disabledProp) ?? false,
-          checked: isChecked,
-          selected: isSelected,
+          checked: isSelected,
         }}
         {...props}
       />

--- a/packages/toggle/package.json
+++ b/packages/toggle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/toggle",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive toggle",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/toggle/src/toggle.tsx
+++ b/packages/toggle/src/toggle.tsx
@@ -26,10 +26,10 @@ const Root = ({
       ref={ref}
       aria-disabled={disabled}
       role='switch'
-      aria-selected={pressed}
+      aria-checked={pressed}
       onPress={onPress}
       accessibilityState={{
-        selected: pressed,
+        checked: pressed,
         disabled,
       }}
       disabled={disabled}

--- a/packages/toolbar/package.json
+++ b/packages/toolbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/toolbar",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive toolbar",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/toolbar/src/toolbar.tsx
+++ b/packages/toolbar/src/toolbar.tsx
@@ -56,7 +56,7 @@ const ToggleGroup = ({
         } as ToggleGroupProps
       }
     >
-      <Component ref={ref} role='group' {...viewProps} />
+      <Component ref={ref} role={type === 'single' ? 'radiogroup' : 'group'} {...viewProps} />
     </ToggleGroupContext.Provider>
   );
 };
@@ -95,10 +95,7 @@ const ToggleItem = ({
     onPressProp?.(ev);
   }
 
-  const isChecked =
-    type === 'single' ? ToggleGroupUtils.getIsSelected(value, itemValue) : undefined;
-  const isSelected =
-    type === 'multiple' ? ToggleGroupUtils.getIsSelected(value, itemValue) : undefined;
+  const isSelected = ToggleGroupUtils.getIsSelected(value, itemValue);
 
   const Component = asChild ? Slot : Pressable;
   return (
@@ -107,13 +104,11 @@ const ToggleItem = ({
       aria-disabled={disabled}
       role={type === 'single' ? 'radio' : 'checkbox'}
       onPress={onPress}
-      aria-checked={isChecked}
-      aria-selected={isSelected}
+      aria-checked={isSelected}
       disabled={(disabled || disabledProp) ?? false}
       accessibilityState={{
         disabled: (disabled || disabledProp) ?? false,
-        checked: isChecked,
-        selected: isSelected,
+        checked: isSelected,
       }}
       {...props}
     />

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/tooltip",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive tooltip",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/tooltip/src/tooltip.tsx
+++ b/packages/tooltip/src/tooltip.tsx
@@ -1,4 +1,5 @@
 import {
+  useAccessibilityFocus,
   useComposedRefs,
   useEffectEvent,
   useRelativePosition,
@@ -135,7 +136,9 @@ const Trigger = ({
     <Component
       ref={composedRef}
       aria-disabled={disabled ?? undefined}
+      aria-expanded={open}
       role='button'
+      accessibilityState={{ disabled: disabled ?? false, expanded: open }}
       onPress={onPress}
       disabled={disabled ?? undefined}
       {...props}
@@ -195,7 +198,7 @@ const Overlay = ({
   }
 
   const Component = asChild ? Slot : Pressable;
-  return <Component ref={ref} onPress={onPress} {...props} />;
+  return <Component ref={ref} accessible={false} onPress={onPress} {...props} />;
 };
 
 Overlay.displayName = 'OverlayNativeTooltip';
@@ -219,12 +222,13 @@ const Content = ({
   const {
     open,
     onOpenChange,
-    nativeID,
     contentLayout,
     setContentLayout,
     setTriggerPosition,
     triggerPosition,
   } = useTooltipContext();
+  const accessibilityFocusRef = useAccessibilityFocus<ContentRef>(open);
+  const composedRef = useComposedRefs(ref, accessibilityFocusRef);
 
   React.useEffect(() => {
     const backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
@@ -266,10 +270,13 @@ const Content = ({
   const Component = asChild ? Slot : View;
   return (
     <Component
-      ref={ref}
+      ref={composedRef}
       role='tooltip'
-      nativeID={nativeID}
-      aria-modal={true}
+      onAccessibilityEscape={() => {
+        setTriggerPosition(null);
+        setContentLayout(null);
+        onOpenChange(false);
+      }}
       style={[positionStyle, style]}
       onLayout={onLayout}
       onStartShouldSetResponder={onStartShouldSetResponder}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/types",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive types",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/utils",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Primitive types",
   "license": "MIT",
   "main": "dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1509,6 +1509,9 @@ importers:
 
   packages/toast:
     dependencies:
+      '@rn-primitives/hooks':
+        specifier: workspace:*
+        version: link:../hooks
       '@rn-primitives/slot':
         specifier: workspace:*
         version: link:../slot
@@ -4368,6 +4371,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -4525,6 +4529,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -8797,6 +8802,7 @@ packages:
 
   uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   validate-npm-package-name@5.0.1:


### PR DESCRIPTION
# Changelog — Accessibility overhaul (native only; `.web.tsx` untouched)

## Highlights

- **Fixed: menus/popovers unusable with VoiceOver & TalkBack.** `Pressable` defaults to `accessible={true}`, so overlay backdrops and Pressable-based menu containers collapsed into a single accessibility element — screen readers could never reach the items inside. All container Pressables are now `accessible={false}`.
- **New: screen-reader focus management.** Overlay-style components move VoiceOver/TalkBack focus into their content when opened, and dismiss via the iOS escape gesture (two-finger Z scrub). Submenus do the same when they expand — without this, VoiceOver's stale element list made freshly-mounted submenu items unreachable.
- **Removed all `nativeID` props on native views** (and the `aria-labelledby`/`aria-describedby` pointing at them). They break Reanimated exiting animations and provide no native screen-reader benefit. `useId` values used purely as Portal host names are kept.

## `@rn-primitives/hooks`

- **Added** `useAccessibilityFocus(enabled)` — moves screen-reader focus to the attached element when `enabled` becomes true (50 ms cancelable timeout, no deprecated `InteractionManager`). Target must not be `accessible={true}`; focus resolves to the first accessible descendant.

## Menus — `dropdown-menu`, `context-menu`, `menubar`

- **Fixed** items unselectable with screen readers: `accessible={false}` on Overlay, Pressable Content (dropdown-menu), and SubContents.
- **Fixed** submenu items unreachable after expanding a SubTrigger: SubContent moves screen-reader focus into itself on open.
- **Fixed** `CheckboxItem` missing `checked` in `accessibilityState`.
- Content/SubContent: focus-on-open, `onAccessibilityEscape` to dismiss (SubContent escape closes only the submenu).
- `textValue` now maps to `aria-label` (was `aria-valuetext`, which is for ranges).
- SubContent: `role='menu'` (was `role='group'` + useless `aria-labelledby`).
- menubar: `role='menubar'` moved from each `Menu` to `Root`; `Menu` is now `role='group'`.
- Triggers expose `accessibilityState` (`expanded`, `disabled`).

## Overlay components — `dialog`, `alert-dialog`, `popover`, `hover-card`, `tooltip`, `select`

- Content moves screen-reader focus into itself on open; `onAccessibilityEscape` dismisses.
- Overlays (backdrop Pressables): `accessible={false}`.
- Triggers announce `expanded`/`disabled` state.
- dialog/alert-dialog Cancel/Action/Close: `accessibilityState.disabled`.
- tooltip Content: removed incorrect `aria-modal` (tooltips aren't modal).
- select Item: `aria-selected` + `accessibilityState.selected` (was `checked` — wrong state for `role='option'`); `label` → `aria-label`.
- Toast: foreground toasts announce as `role='alert'` and receive screen-reader focus on mount (live regions don't fire for freshly-mounted views); background toasts stay `role='status'`/polite. Added `@rn-primitives/hooks` dependency.

## Form & value primitives

- **slider**: screen-reader increment/decrement now works — Track exposes `accessibilityActions` wired to `step`/`onValueChange` (previously discarded on native, docs said "WEB ONLY"); Track is `accessible` with disabled state; Thumb is `role='presentation'` (no more duplicate "adjustable" element).
- **switch**: fixed operator-precedence bug — custom `aria-valuetext` was always announced as `"on"`.
- **toggle**: `role='switch'` now pairs with `checked` state (was `selected`, which never announced on/off).
- **toggle-group / toolbar**: `type='multiple'` items (checkbox role) now announce `checked` (previously only `selected`); `type='single'` groups announce as `radiogroup`; removed dead `useId`.
- **progress**: `accessible={true}` so the progressbar is focusable and its value text is read.
- **checkbox**: removed `nativeID` plumbing.
- **separator**: `aria-hidden` when `decorative`.

## Structure & navigation

- **accordion**: Trigger `aria-expanded`; Content is always `role='region'` (was nonsensical `'summary'` for `type='multiple'`).
- **collapsible**: Trigger `aria-expanded`; removed `nativeID`/labelledby.
- **tabs**: removed `nativeID` + `aria-labelledby` plumbing (roles/states were already correct).
- **table**: `Header` is `role='rowgroup'` (was `'rowheader'`, a cell role).
- **navigation-menu**: `List`/`Item` are `list`/`listitem` (were incorrect `menubar`/`menuitem`); Content is `role='group'` with focus-on-open + escape; Indicator hidden from screen readers.

## ⚠️ Breaking (internal API)

- `nativeID` is no longer exposed on these context hooks: accordion `useItemContext()`, tabs `useRootContext()`, and the menu packages' `useSubContext()`. Consumers reading it should stop passing it to views (it breaks Reanimated exiting animations).
- checkbox `Root` no longer forwards an explicit `nativeID` to its Trigger.

Suggested version: **1.5.0** (behavior changes + new hook, no public-prop removals outside the context fields above). Want me to turn this into changeset files so `pnpm version-bump` picks it up?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved screen reader support across dialogs, menus, popovers, tooltips, accordions, selects, tabs, sliders, and toggles.
  * Added clearer focus handling and escape gestures to close open overlays and menus.
  * Updated interactive controls to report better expanded/checked/selected states for accessibility.

* **Bug Fixes**
  * Fixed toggle and switch accessibility labels so they announce the correct state.
  * Improved progress, separator, and table accessibility roles for more consistent screen reader behavior.

* **Chores**
  * Bumped package versions across the library set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->