### PR TITLE
feat: enhance documentation and styling for rn-primitives

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "docs",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--dir", "apps/docs", "run", "dev", "--port", "4399"],
+      "port": 4399,
+      "autoPort": false
+    }
+  ]
+}

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -5,16 +5,39 @@ import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({
+  site: 'https://rnprimitives.com',
   output: 'static',
   adapters: [],
   integrations: [
     starlight({
       favicon: '/favicon.png',
       title: 'rn-primitives',
-      description: 'Documentation for rn-primitives',
+      description:
+        'Unstyled, accessible React Native components with a unified API for iOS, Android, and Web.',
+      logo: {
+        dark: './src/assets/logo-dark.svg',
+        light: './src/assets/logo-light.svg',
+        alt: 'rn-primitives',
+      },
       components: {
         ThemeSelect: './src/components/ThemeSelect.astro',
         Head: './src/components/Head.astro',
+      },
+      expressiveCode: {
+        themes: ['github-dark-default', 'github-light-default'],
+        styleOverrides: {
+          borderRadius: '0.75rem',
+          borderColor: 'var(--sl-color-hairline-light)',
+          codeFontFamily: "'JetBrains Mono Variable', ui-monospace, 'SF Mono', Menlo, monospace",
+          codeFontSize: '0.8125rem',
+          codeLineHeight: '1.7',
+          uiFontFamily: "'Inter Variable', ui-sans-serif, system-ui, sans-serif",
+          frames: {
+            frameBoxShadowCssValue: 'none',
+            editorActiveTabIndicatorTopColor: 'var(--sl-color-accent)',
+            editorActiveTabIndicatorHeight: '2px',
+          },
+        },
       },
       social: [
         { icon: 'github', label: 'GitHub', href: 'https://github.com/roninoss/rn-primitives' },
@@ -163,7 +186,12 @@ export default defineConfig({
           ],
         },
       ],
-      customCss: ['./src/tailwind.css'],
+      customCss: [
+        '@fontsource-variable/inter',
+        '@fontsource-variable/jetbrains-mono',
+        './src/tailwind.css',
+        './src/styles/theme.css',
+      ],
     }),
     tailwind({
       applyBaseStyles: false,

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -16,6 +16,8 @@
     "@astrojs/starlight": "^0.34.3",
     "@astrojs/starlight-tailwind": "^2.0.1",
     "@astrojs/tailwind": "^5.1.0",
+    "@fontsource-variable/inter": "^5.2.8",
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-slot": "^1.2.4",

--- a/apps/docs/src/assets/logo-dark.svg
+++ b/apps/docs/src/assets/logo-dark.svg
@@ -1,0 +1,6 @@
+<svg width="88" height="24" viewBox="0 0 88 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="10.75" stroke="#fafafa" stroke-opacity="0.7" stroke-width="2" stroke-dasharray="4 3.4" stroke-linecap="round" />
+  <rect x="33" y="1" width="22" height="22" rx="7" stroke="#fafafa" stroke-opacity="0.7" stroke-width="2" />
+  <rect x="64" y="0" width="24" height="24" rx="7.5" fill="#7c66dc" />
+  <rect x="71" y="7" width="10" height="10" rx="3" fill="#fafafa" fill-opacity="0.92" />
+</svg>

--- a/apps/docs/src/assets/logo-light.svg
+++ b/apps/docs/src/assets/logo-light.svg
@@ -1,0 +1,6 @@
+<svg width="88" height="24" viewBox="0 0 88 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="10.75" stroke="#17171b" stroke-opacity="0.7" stroke-width="2" stroke-dasharray="4 3.4" stroke-linecap="round" />
+  <rect x="33" y="1" width="22" height="22" rx="7" stroke="#17171b" stroke-opacity="0.7" stroke-width="2" />
+  <rect x="64" y="0" width="24" height="24" rx="7.5" fill="#6550b9" />
+  <rect x="71" y="7" width="10" height="10" rx="3" fill="#ffffff" fill-opacity="0.95" />
+</svg>

--- a/apps/docs/src/components/PrimitiveGrid.astro
+++ b/apps/docs/src/components/PrimitiveGrid.astro
@@ -1,0 +1,24 @@
+---
+interface Item {
+  name: string;
+  href: string;
+  description: string;
+}
+
+interface Props {
+  items: Item[];
+}
+
+const { items } = Astro.props;
+---
+
+<div class="rnp-grid not-content">
+  {
+    items.map((item) => (
+      <a class="rnp-card" href={item.href}>
+        <span class="rnp-card-title">{item.name}</span>
+        <span class="rnp-card-desc">{item.description}</span>
+      </a>
+    ))
+  }
+</div>

--- a/apps/docs/src/components/ReusablesBadge.astro
+++ b/apps/docs/src/components/ReusablesBadge.astro
@@ -1,0 +1,41 @@
+---
+interface Props {
+  href: string;
+}
+
+const { href } = Astro.props;
+---
+
+<a class="rnp-reusables-badge not-content" href={href} target="_blank" rel="noopener noreferrer">
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="13"
+    height="13"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M12 2a10 10 0 1 0 10 10H12V2Z"></path>
+    <path d="M21.18 8.02A10 10 0 0 0 15.97 2.8"></path>
+  </svg>
+  <span>Styled version in <strong>React Native Reusables</strong></span>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="12"
+    height="12"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M7 7h10v10"></path>
+    <path d="M7 17 17 7"></path>
+  </svg>
+</a>

--- a/apps/docs/src/content/docs/accordion.mdx
+++ b/apps/docs/src/content/docs/accordion.mdx
@@ -13,6 +13,9 @@ import importedNativeCode from '@/../node_modules/@rn-primitives/accordion/src/a
 import importedWebCode from '@/../node_modules/@rn-primitives/accordion/src/accordion.web.tsx?raw';
 import importedTypesCode from '@/../node_modules/@rn-primitives/accordion/src/types.ts?raw';
 import importedIndexCode from '@/../node_modules/@rn-primitives/accordion/src/index.ts?raw';
+import ReusablesBadge from '@/components/ReusablesBadge.astro';
+
+<ReusablesBadge href="https://reactnativereusables.com/docs/components/accordion" />
 
 A vertically stacked set of interactive headings that each reveal a section of content.
 

--- a/apps/docs/src/content/docs/alert-dialog.mdx
+++ b/apps/docs/src/content/docs/alert-dialog.mdx
@@ -13,6 +13,9 @@ import importedNativeCode from '@/../node_modules/@rn-primitives/alert-dialog/sr
 import importedWebCode from '@/../node_modules/@rn-primitives/alert-dialog/src/alert-dialog.web.tsx?raw';
 import importedTypesCode from '@/../node_modules/@rn-primitives/alert-dialog/src/types.ts?raw';
 import importedIndexCode from '@/../node_modules/@rn-primitives/alert-dialog/src/index.ts?raw';
+import ReusablesBadge from '@/components/ReusablesBadge.astro';
+
+<ReusablesBadge href="https://reactnativereusables.com/docs/components/alert-dialog" />
 
 A modal dialog that interrupts the user with important content and expects a response.
 

--- a/apps/docs/src/content/docs/aspect-ratio.mdx
+++ b/apps/docs/src/content/docs/aspect-ratio.mdx
@@ -10,6 +10,9 @@ import Code from '@/components/ManualCode.astro';
 import { LinkButton } from '@/components/react/LinkButton';
 import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 import importedCode from '@/../node_modules/@rn-primitives/aspect-ratio/src/aspect-ratio.tsx?raw';
+import ReusablesBadge from '@/components/ReusablesBadge.astro';
+
+<ReusablesBadge href="https://reactnativereusables.com/docs/components/aspect-ratio" />
 
 
 Presents content within a chosen aspect ratio.

--- a/apps/docs/src/content/docs/avatar.mdx
+++ b/apps/docs/src/content/docs/avatar.mdx
@@ -11,6 +11,9 @@ import { LinkButton } from '@/components/react/LinkButton';
 import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 import importedNativeCode from '@/../node_modules/@rn-primitives/avatar/src/avatar.tsx?raw';
 import importedTypesCode from '@/../node_modules/@rn-primitives/avatar/src/types.ts?raw';
+import ReusablesBadge from '@/components/ReusablesBadge.astro';
+
+<ReusablesBadge href="https://reactnativereusables.com/docs/components/avatar" />
 
 
 An image component featuring an alternative representation for depicting the user.

--- a/apps/docs/src/content/docs/checkbox.mdx
+++ b/apps/docs/src/content/docs/checkbox.mdx
@@ -13,6 +13,9 @@ import importedNativeCode from '@/../node_modules/@rn-primitives/checkbox/src/ch
 import importedWebCode from '@/../node_modules/@rn-primitives/checkbox/src/checkbox.web.tsx?raw';
 import importedTypesCode from '@/../node_modules/@rn-primitives/checkbox/src/types.ts?raw';
 import importedIndexCode from '@/../node_modules/@rn-primitives/checkbox/src/index.ts?raw';
+import ReusablesBadge from '@/components/ReusablesBadge.astro';
+
+<ReusablesBadge href="https://reactnativereusables.com/docs/components/checkbox" />
 
 
 A box that is a checked (ticked) indicator when activated.

--- a/apps/docs/src/content/docs/collapsible.mdx
+++ b/apps/docs/src/content/docs/collapsible.mdx
@@ -13,6 +13,9 @@ import importedNativeCode from '@/../node_modules/@rn-primitives/collapsible/src
 import importedWebCode from '@/../node_modules/@rn-primitives/collapsible/src/collapsible.web.tsx?raw';
 import importedTypesCode from '@/../node_modules/@rn-primitives/collapsible/src/types.ts?raw';
 import importedIndexCode from '@/../node_modules/@rn-primitives/collapsible/src/index.ts?raw';
+import ReusablesBadge from '@/components/ReusablesBadge.astro';
+
+<ReusablesBadge href="https://reactnativereusables.com/docs/components/collapsible" />
 
 
 A dynamic element that facilitates the expansion or collapse of a panel.

--- a/apps/docs/src/content/docs/context-menu.mdx
+++ b/apps/docs/src/content/docs/context-menu.mdx
@@ -13,6 +13,9 @@ import importedNativeCode from '@/../node_modules/@rn-primitives/context-menu/sr
 import importedWebCode from '@/../node_modules/@rn-primitives/context-menu/src/context-menu.web.tsx?raw';
 import importedTypesCode from '@/../node_modules/@rn-primitives/context-menu/src/types.ts?raw';
 import importedIndexCode from '@/../node_modules/@rn-primitives/context-menu/src/index.ts?raw';
+import ReusablesBadge from '@/components/ReusablesBadge.astro';
+
+<ReusablesBadge href="https://reactnativereusables.com/docs/components/context-menu" />
 
 
 Shows a menu activated by either a right-click or a long-press.

--- a/apps/docs/src/content/docs/dialog.mdx
+++ b/apps/docs/src/content/docs/dialog.mdx
@@ -13,6 +13,9 @@ import importedNativeCode from '@/../node_modules/@rn-primitives/dialog/src/dial
 import importedWebCode from '@/../node_modules/@rn-primitives/dialog/src/dialog.web.tsx?raw';
 import importedTypesCode from '@/../node_modules/@rn-primitives/dialog/src/types.ts?raw';
 import importedIndexCode from '@/../node_modules/@rn-primitives/dialog/src/index.ts?raw';
+import ReusablesBadge from '@/components/ReusablesBadge.astro';
+
+<ReusablesBadge href="https://reactnativereusables.com/docs/components/dialog" />
 
 A modal dialog that interrupts the user with important content and expects a response.
 

--- a/apps/docs/src/content/docs/dropdown-menu.mdx
+++ b/apps/docs/src/content/docs/dropdown-menu.mdx
@@ -13,6 +13,9 @@ import importedNativeCode from '@/../node_modules/@rn-primitives/dropdown-menu/s
 import importedWebCode from '@/../node_modules/@rn-primitives/dropdown-menu/src/dropdown-menu.web.tsx?raw';
 import importedTypesCode from '@/../node_modules/@rn-primitives/dropdown-menu/src/types.ts?raw';
 import importedIndexCode from '@/../node_modules/@rn-primitives/dropdown-menu/src/index.ts?raw';
+import ReusablesBadge from '@/components/ReusablesBadge.astro';
+
+<ReusablesBadge href="https://reactnativereusables.com/docs/components/dropdown-menu" />
 
 Shows a menu with options or actions when a user clicks the trigger button.
 

--- a/apps/docs/src/content/docs/hover-card.mdx
+++ b/apps/docs/src/content/docs/hover-card.mdx
@@ -13,6 +13,9 @@ import importedNativeCode from '@/../node_modules/@rn-primitives/hover-card/src/
 import importedWebCode from '@/../node_modules/@rn-primitives/hover-card/src/hover-card.web.tsx?raw';
 import importedTypesCode from '@/../node_modules/@rn-primitives/hover-card/src/types.ts?raw';
 import importedIndexCode from '@/../node_modules/@rn-primitives/hover-card/src/index.ts?raw';
+import ReusablesBadge from '@/components/ReusablesBadge.astro';
+
+<ReusablesBadge href="https://reactnativereusables.com/docs/components/hover-card" />
 
 Allows users with vision to preview the content hidden behind an element before hovering or pressing.
 

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -1,138 +1,249 @@
 ---
-title: Introduction
-description: Elevating Component Development
+title: React Native Primitives
+description: Unstyled, accessible React Native components with a unified API for iOS, Android, and Web.
+template: splash
+hero:
+  title: Style-free building blocks for React Native
+  tagline: Unstyled, accessible primitives with a unified API across iOS, Android, and Web. Bring your own styles, we handle the behavior, accessibility, and platform differences.
+  actions:
+    - text: Browse primitives
+      link: '#core-primitives'
+      icon: right-arrow
+    - text: View on GitHub
+      link: https://github.com/roninoss/rn-primitives
+      icon: github
+      variant: minimal
 ---
-{/* prettier-ignore-start */}
-{/* prettier-ignore-end */}
 
-import { Card } from '@astrojs/starlight/components';
-import { Aside } from '@astrojs/starlight/components';
-import { LinkButton } from '@/components/react/LinkButton';
+import PrimitiveGrid from '@/components/PrimitiveGrid.astro';
 
-
-## React Native Primitives
-
-Unstyled universal components with a focus on accessibility. They offer a unified API across iOS, Android, and web platforms.
-
-
-<Aside type="tip" title="Adaptable React Native Components">
-  Use via npm dependencies or copy-paste the source code directly into your project.
-</Aside>
-
- ### Core Primitives
-
- Elements of the user interface.
-
-    <div className="flex gap-2 items-center flex-wrap justify-center">
-    <LinkButton href="/accordion">
-      Accordion
-    </LinkButton>
-    <LinkButton href="/alert-dialog">
-      Alert-dialog
-    </LinkButton>
-    <LinkButton href="/aspect-ratio">
-      Aspect-ratio
-    </LinkButton>
-    <LinkButton href="/avatar">
-      Avatar
-    </LinkButton>
-    <LinkButton href="/checkbox">
-      Checkbox
-    </LinkButton>
-    <LinkButton href="/collapsible">
-      Collapsible
-    </LinkButton>
-    <LinkButton href="/context-menu">
-      Context-menu
-    </LinkButton>
-    <LinkButton href="/dialog">
-      Dialog
-    </LinkButton>
-    <LinkButton href="/dropdown-menu">
-      Dropdown-menu
-    </LinkButton>
-    <LinkButton href="/hover-card">
-      Hover-card
-    </LinkButton>
-    <LinkButton href="/label">
-      Label
-    </LinkButton>
-    <LinkButton href="/menubar">
-      Menubar
-    </LinkButton>
-    <LinkButton href="/navigation-menu">
-      Navigation-menu
-    </LinkButton>
-    <LinkButton href="/popover">
-      Popover
-    </LinkButton>
-    <LinkButton href="/portal">
-      Portal
-    </LinkButton>
-    <LinkButton href="/progress">
-      Progress
-    </LinkButton>
-    <LinkButton href="/radio-group">
-      Radio-group
-    </LinkButton>
-    <LinkButton href="/select">
-      Select
-    </LinkButton>
-    <LinkButton href="/separator">
-      Separator
-    </LinkButton>
-    <LinkButton href="/slider">
-      Slider
-    </LinkButton>
-    <LinkButton href="/switch">
-      Switch
-    </LinkButton>
-    <LinkButton href="/table">
-      Table
-    </LinkButton>
-    <LinkButton href="/tabs">
-      Tabs
-    </LinkButton>
-    <LinkButton href="/toast">
-      Toast
-    </LinkButton>
-    <LinkButton href="/toggle">
-      Toggle
-    </LinkButton>
-    <LinkButton href="/toggle-group">
-      Toggle-group
-    </LinkButton>
-    <LinkButton href="/toolbar">
-      Toolbar
-    </LinkButton>
-    <LinkButton href="/tooltip">
-      Tooltip
-    </LinkButton>
+<div className='rnp-features not-content'>
+  <div className='rnp-feature'>
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      width='20'
+      height='20'
+      viewBox='0 0 24 24'
+      fill='none'
+      stroke='currentColor'
+      strokeWidth='2'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    >
+      <rect width='14' height='20' x='5' y='2' rx='2' ry='2' />
+      <path d='M12 18h.01' />
+    </svg>
+    <h3>Truly universal</h3>
+    <p>
+      One API across iOS, Android, and Web. Radix UI powers the web side; native implementations
+      power the rest.
+    </p>
   </div>
-
-### Shared Primitives
-
-  Tools and functionalities for a more efficient and extensible development process.
-
-  <div className="flex gap-2 items-center flex-wrap justify-center">
-    <LinkButton href="/hooks">
-      Hooks
-    </LinkButton>
-    <LinkButton href="/portal">
-      Portal
-    </LinkButton>
-    <LinkButton href="/slot">
-      Slot
-    </LinkButton>
-    <LinkButton href="/types">
-      Types
-    </LinkButton>
-    <LinkButton href="/utils">
-      Utils
-    </LinkButton>
+  <div className='rnp-feature'>
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      width='20'
+      height='20'
+      viewBox='0 0 24 24'
+      fill='none'
+      stroke='currentColor'
+      strokeWidth='2'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    >
+      <circle cx='16' cy='4' r='1' />
+      <path d='m18 19 1-7-6 1' />
+      <path d='m5 8 3-3 5.5 3-2.36 3.5' />
+      <path d='M4.24 14.5a5 5 0 0 0 6.88 6' />
+      <path d='M13.76 17.5a5 5 0 0 0-6.88-6' />
+    </svg>
+    <h3>Accessible by default</h3>
+    <p>
+      Screen-reader support, focus management, and platform-correct semantics are built in, not
+      bolted on.
+    </p>
   </div>
+  <div className='rnp-feature'>
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      width='20'
+      height='20'
+      viewBox='0 0 24 24'
+      fill='none'
+      stroke='currentColor'
+      strokeWidth='2'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    >
+      <path d='m9.06 11.9 8.07-8.06a2.85 2.85 0 1 1 4.03 4.03l-8.06 8.08' />
+      <path d='M7.07 14.94c-1.66 0-3 1.35-3 3.02 0 1.33-2.5 1.52-2 2.02 1.08 1.1 2.49 2.02 4 2.02 2.2 0 4-1.8 4-4.04a3.01 3.01 0 0 0-3-3.02z' />
+    </svg>
+    <h3>Unstyled on purpose</h3>
+    <p>
+      No design system to fight. Every primitive ships zero styles, so your components look like
+      your app.
+    </p>
+  </div>
+  <div className='rnp-feature'>
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      width='20'
+      height='20'
+      viewBox='0 0 24 24'
+      fill='none'
+      stroke='currentColor'
+      strokeWidth='2'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    >
+      <path d='m7.5 4.27 9 5.15' />
+      <path d='M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z' />
+      <path d='m3.3 7 8.7 5 8.7-5' />
+      <path d='M12 22V12' />
+    </svg>
+    <h3>Install or copy-paste</h3>
+    <p>Use the npm packages, or copy the source straight into your project and own every line.</p>
+  </div>
+</div>
 
+<h2 id='core-primitives' className='rnp-section-title'>
+  Core primitives
+</h2>
 
+<PrimitiveGrid
+  items={[
+    {
+      name: 'Accordion',
+      href: '/accordion',
+      description: 'Vertically stacked sections that expand and collapse.',
+    },
+    {
+      name: 'Alert Dialog',
+      href: '/alert-dialog',
+      description: 'A modal that interrupts the user with important content.',
+    },
+    {
+      name: 'Aspect Ratio',
+      href: '/aspect-ratio',
+      description: 'Constrains content to a given width-to-height ratio.',
+    },
+    {
+      name: 'Avatar',
+      href: '/avatar',
+      description: 'An image with an automatic fallback while loading or on error.',
+    },
+    {
+      name: 'Checkbox',
+      href: '/checkbox',
+      description: 'A control that toggles between checked and unchecked.',
+    },
+    {
+      name: 'Collapsible',
+      href: '/collapsible',
+      description: 'A panel that expands and collapses its content.',
+    },
+    {
+      name: 'Context Menu',
+      href: '/context-menu',
+      description: 'A menu opened by long press or right click.',
+    },
+    { name: 'Dialog', href: '/dialog', description: 'A window overlaid on the primary content.' },
+    {
+      name: 'Dropdown Menu',
+      href: '/dropdown-menu',
+      description: 'A menu of actions opened from a trigger.',
+    },
+    {
+      name: 'Hover Card',
+      href: '/hover-card',
+      description: 'Preview content shown on hover for sighted users.',
+    },
+    {
+      name: 'Label',
+      href: '/label',
+      description: 'An accessible caption associated with a control.',
+    },
+    {
+      name: 'Menubar',
+      href: '/menubar',
+      description: 'A persistent bar of menus with nested submenus.',
+    },
+    {
+      name: 'Navigation Menu',
+      href: '/navigation-menu',
+      description: 'A collection of links for navigating your app.',
+    },
+    {
+      name: 'Popover',
+      href: '/popover',
+      description: 'Rich content rendered in a portal from a trigger.',
+    },
+    { name: 'Progress', href: '/progress', description: 'Displays completion progress of a task.' },
+    {
+      name: 'Radio Group',
+      href: '/radio-group',
+      description: 'A set of mutually exclusive checkable buttons.',
+    },
+    {
+      name: 'Select',
+      href: '/select',
+      description: 'A list of options for the user to pick from.',
+    },
+    {
+      name: 'Separator',
+      href: '/separator',
+      description: 'Visually or semantically separates content.',
+    },
+    { name: 'Slider', href: '/slider', description: 'Select a value from within a given range.' },
+    { name: 'Switch', href: '/switch', description: 'A control that toggles between on and off.' },
+    { name: 'Table', href: '/table', description: 'Semantic table components for tabular data.' },
+    {
+      name: 'Tabs',
+      href: '/tabs',
+      description: 'Layered sections of content shown one at a time.',
+    },
+    { name: 'Toast', href: '/toast', description: 'A brief message that shows up temporarily.' },
+    { name: 'Toggle', href: '/toggle', description: 'A two-state button that can be on or off.' },
+    {
+      name: 'Toggle Group',
+      href: '/toggle-group',
+      description: 'A group of two-state toggle buttons.',
+    },
+    {
+      name: 'Toolbar',
+      href: '/toolbar',
+      description: 'A container for grouping buttons and controls.',
+    },
+    {
+      name: 'Tooltip',
+      href: '/tooltip',
+      description: 'Contextual information shown on hover or focus.',
+    },
+  ]}
+/>
 
+<h2 id='shared-primitives' className='rnp-section-title'>
+  Shared primitives
+</h2>
 
-
+<PrimitiveGrid
+  items={[
+    { name: 'Hooks', href: '/hooks', description: 'Shared hooks used across the primitives.' },
+    {
+      name: 'Portal',
+      href: '/portal',
+      description: 'Render children into a different part of the tree.',
+    },
+    {
+      name: 'Slot',
+      href: '/slot',
+      description: 'Merge props onto an immediate child with asChild.',
+    },
+    { name: 'Types', href: '/types', description: 'Shared TypeScript types for all primitives.' },
+    {
+      name: 'Utils',
+      href: '/utils',
+      description: 'Shared utility functions used across packages.',
+    },
+  ]}
+/>

--- a/apps/docs/src/content/docs/label.mdx
+++ b/apps/docs/src/content/docs/label.mdx
@@ -13,6 +13,9 @@ import importedNativeCode from '@/../node_modules/@rn-primitives/label/src/label
 import importedWebCode from '@/../node_modules/@rn-primitives/label/src/label.web.tsx?raw';
 import importedTypesCode from '@/../node_modules/@rn-primitives/label/src/types.ts?raw';
 import importedIndexCode from '@/../node_modules/@rn-primitives/label/src/index.ts?raw';
+import ReusablesBadge from '@/components/ReusablesBadge.astro';
+
+<ReusablesBadge href="https://reactnativereusables.com/docs/components/label" />
 
 A user-friendly label linked to controls for improved accessibility.
 

--- a/apps/docs/src/content/docs/menubar.mdx
+++ b/apps/docs/src/content/docs/menubar.mdx
@@ -13,6 +13,9 @@ import importedNativeCode from '@/../node_modules/@rn-primitives/menubar/src/men
 import importedWebCode from '@/../node_modules/@rn-primitives/menubar/src/menubar.web.tsx?raw';
 import importedTypesCode from '@/../node_modules/@rn-primitives/menubar/src/types.ts?raw';
 import importedIndexCode from '@/../node_modules/@rn-primitives/menubar/src/index.ts?raw';
+import ReusablesBadge from '@/components/ReusablesBadge.astro';
+
+<ReusablesBadge href="https://reactnativereusables.com/docs/components/menubar" />
 
 A menu that stays visible on the screen, often seen in desktop apps, offering easy access to a standard set of commands.
 

--- a/apps/docs/src/content/docs/popover.mdx
+++ b/apps/docs/src/content/docs/popover.mdx
@@ -13,6 +13,9 @@ import importedNativeCode from '@/../node_modules/@rn-primitives/popover/src/pop
 import importedWebCode from '@/../node_modules/@rn-primitives/popover/src/popover.web.tsx?raw';
 import importedTypesCode from '@/../node_modules/@rn-primitives/popover/src/types.ts?raw';
 import importedIndexCode from '@/../node_modules/@rn-primitives/popover/src/index.ts?raw';
+import ReusablesBadge from '@/components/ReusablesBadge.astro';
+
+<ReusablesBadge href="https://reactnativereusables.com/docs/components/popover" />
 
 
 Dynamic content within a portal, activated by a button press.

--- a/apps/docs/src/content/docs/progress.mdx
+++ b/apps/docs/src/content/docs/progress.mdx
@@ -13,6 +13,9 @@ import importedNativeCode from '@/../node_modules/@rn-primitives/progress/src/pr
 import importedWebCode from '@/../node_modules/@rn-primitives/progress/src/progress.web.tsx?raw';
 import importedTypesCode from '@/../node_modules/@rn-primitives/progress/src/types.ts?raw';
 import importedIndexCode from '@/../node_modules/@rn-primitives/progress/src/index.ts?raw';
+import ReusablesBadge from '@/components/ReusablesBadge.astro';
+
+<ReusablesBadge href="https://reactnativereusables.com/docs/components/progress" />
 
 Shows an indicator representing the advancement status of a task.
 

--- a/apps/docs/src/content/docs/radio-group.mdx
+++ b/apps/docs/src/content/docs/radio-group.mdx
@@ -13,6 +13,9 @@ import importedNativeCode from '@/../node_modules/@rn-primitives/radio-group/src
 import importedWebCode from '@/../node_modules/@rn-primitives/radio-group/src/radio-group.web.tsx?raw';
 import importedTypesCode from '@/../node_modules/@rn-primitives/radio-group/src/types.ts?raw';
 import importedIndexCode from '@/../node_modules/@rn-primitives/radio-group/src/index.ts?raw';
+import ReusablesBadge from '@/components/ReusablesBadge.astro';
+
+<ReusablesBadge href="https://reactnativereusables.com/docs/components/radio-group" />
 
 
 A group of selectable buttons, commonly referred to as radio buttons, wherein only one button can be checked simultaneously.

--- a/apps/docs/src/content/docs/select.mdx
+++ b/apps/docs/src/content/docs/select.mdx
@@ -13,6 +13,9 @@ import importedNativeCode from '@/../node_modules/@rn-primitives/select/src/sele
 import importedWebCode from '@/../node_modules/@rn-primitives/select/src/select.web.tsx?raw';
 import importedTypesCode from '@/../node_modules/@rn-primitives/select/src/types.ts?raw';
 import importedIndexCode from '@/../node_modules/@rn-primitives/select/src/index.ts?raw';
+import ReusablesBadge from '@/components/ReusablesBadge.astro';
+
+<ReusablesBadge href="https://reactnativereusables.com/docs/components/select" />
 
 Presents a selection of options for the user to choose from, activated by a button.
 

--- a/apps/docs/src/content/docs/separator.mdx
+++ b/apps/docs/src/content/docs/separator.mdx
@@ -11,6 +11,9 @@ import { LinkButton } from '@/components/react/LinkButton';
 import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 import importedCode from '@/../node_modules/@rn-primitives/separator/src/separator.tsx?raw';
 import importedTypesCode from '@/../node_modules/@rn-primitives/separator/src/types.ts?raw';
+import ReusablesBadge from '@/components/ReusablesBadge.astro';
+
+<ReusablesBadge href="https://reactnativereusables.com/docs/components/separator" />
 
 
 Creates a visual or semantic distinction between content.

--- a/apps/docs/src/content/docs/slot.mdx
+++ b/apps/docs/src/content/docs/slot.mdx
@@ -7,16 +7,14 @@ description: Merges its props onto its immediate child.
 {/* prettier-ignore-end */}
 
 import Code from '@/components/ManualCode.astro';
-import { LinkButton } from '@/components/react/LinkButton';
-import { Aside, Card, TabItem, Tabs } from '@astrojs/starlight/components';
+import { Aside, TabItem, Tabs } from '@astrojs/starlight/components';
 import importedCode from '@/../node_modules/@rn-primitives/slot/src/slot.tsx?raw';
 
-Merges its props onto its immediate child. 
+Merges its props onto its immediate child.
 
 <Aside type="tip">
   Can be used to support your own `asChild` prop.
 </Aside>
-
 
 ## Installation
 
@@ -39,72 +37,62 @@ Merges its props onto its immediate child.
 
 ## Usage
 
-### View Slot
+`Slot` works with any component type. Give it a single element as its child and it renders that child with the `Slot`'s props merged onto it. This is the building block for an `asChild` prop:
 
 ```tsx
-import * as Slot from '@rn-primitives/slot';
+import { Slot } from '@rn-primitives/slot';
+import { Pressable, type PressableProps } from 'react-native';
 
-function CustomView({ asChild = true }) {
-  const Component = asChild ? Slot.View : View;
+function Button({ asChild, ...props }: PressableProps & { asChild?: boolean }) {
+  // When `asChild` is true, the child element receives the Button's props
+  const Component = asChild ? Slot : Pressable;
+  return <Component {...props} />;
+}
+
+function Example() {
   return (
-    <Component className="bg-red-500">
-      {/* The `className` is passed down to the `View` with `key="x"` when `asChild` is `true` */}
-      <View key="x" />
-    </Component>
+    <Button asChild onPress={() => console.log('pressed')}>
+      {/* The Link is rendered and receives the Button's `onPress` */}
+      <Link href="/docs" />
+    </Button>
   );
 }
 ```
 
-### Pressable Slot
+<Aside type="caution" title="Deprecated: Slot.View, Slot.Pressable, Slot.Text, and Slot.Image">
+  The per-component slots are deprecated. Replace them with the single `Slot` component — it
+  handles every component type.
 
-```tsx
-import * as Slot from '@rn-primitives/slot';
+  ```diff lang="tsx"
+  - import * as Slot from '@rn-primitives/slot';
+  + import { Slot } from '@rn-primitives/slot';
 
-function CustomPressable() {
-  return (
-    <Slot.Pressable onPress={() => { console.log("Pressed")}}>
-      {/* The `onPress` prop is passed down to the `Pressable` */}
+  - <Slot.Pressable onPress={handlePress}>
+  + <Slot onPress={handlePress}>
       <Pressable />
-    </Slot.Pressable>
-  );
-}
-```
+  - </Slot.Pressable>
+  + </Slot>
+  ```
+</Aside>
 
-### Text Slot
+### How props are merged
 
-```tsx
-import * as Slot from '@rn-primitives/slot';
+When a prop exists on both the `Slot` and its child, they are combined instead of one silently
+winning:
 
-function CustomText() {
-  return (
-    <Slot.Text className="text-blue-500">
-      {/* The `className` is passed down to the `View` */}
-      <Text />
-    </Slot.Text>
-  );
-}
-```
-
-### Image Slot
-
-```tsx
-import * as Slot from '@rn-primitives/slot';
-
-function CustomImage() {
-  return (
-    <Slot.Image source={{ uri: "https://avatars.githubusercontent.com/u/63797719?v=4" }}>
-        {/* The `source` is passed down to the `View` */}
-      <Image />
-    </Slot.Image>
-  );
-}
-```
+|      Prop      |                                Behavior                                 |
+| :------------: | :---------------------------------------------------------------------: |
+| Event handlers | Both run — the child's handler first, then the slot's (`onPress`, etc.) |
+| style          | Merged into a single style array; the child's style wins conflicts      |
+| className      | Joined together (slot's classes first, then the child's)                |
+| ref            | Composed — the slot's ref and the child's ref both receive the node     |
+| Everything else| The child's value takes precedence                                      |
 
 ## Props
 
-Inherits all props from its type of Slot. 
+`Slot` has no props of its own — it accepts the props of whatever component its child is and
+forwards them.
 
-- <LinkButton href="https://reactnative.dev/docs/view#props" target="_blank">Slot.View</LinkButton>
-- <LinkButton href="https://reactnative.dev/docs/pressable#props" target="_blank">Slot.Pressable</LinkButton>
-- <LinkButton href="https://reactnative.dev/docs/text#props" target="_blank">Slot.Text</LinkButton>
-- <LinkButton href="https://reactnative.dev/docs/image" target="_blank">Slot.Image</LinkButton>
+|    Prop    |        Type        |                              Note                               |
+| :--------: | :----------------: | :-------------------------------------------------------------: |
+| children\* | React.ReactElement | A single valid element. Fragments are flattened and each element inside receives the props. Plain text children are not supported. |

--- a/apps/docs/src/content/docs/switch.mdx
+++ b/apps/docs/src/content/docs/switch.mdx
@@ -13,6 +13,9 @@ import importedNativeCode from '@/../node_modules/@rn-primitives/switch/src/swit
 import importedWebCode from '@/../node_modules/@rn-primitives/switch/src/switch.web.tsx?raw';
 import importedTypesCode from '@/../node_modules/@rn-primitives/switch/src/types.ts?raw';
 import importedIndexCode from '@/../node_modules/@rn-primitives/switch/src/index.ts?raw';
+import ReusablesBadge from '@/components/ReusablesBadge.astro';
+
+<ReusablesBadge href="https://reactnativereusables.com/docs/components/switch" />
 
 A control enabling the user to switch between a checked and unchecked state.
 

--- a/apps/docs/src/content/docs/tabs.mdx
+++ b/apps/docs/src/content/docs/tabs.mdx
@@ -13,6 +13,9 @@ import importedNativeCode from '@/../node_modules/@rn-primitives/tabs/src/tabs.t
 import importedWebCode from '@/../node_modules/@rn-primitives/tabs/src/tabs.web.tsx?raw';
 import importedTypesCode from '@/../node_modules/@rn-primitives/tabs/src/types.ts?raw';
 import importedIndexCode from '@/../node_modules/@rn-primitives/tabs/src/index.ts?raw';
+import ReusablesBadge from '@/components/ReusablesBadge.astro';
+
+<ReusablesBadge href="https://reactnativereusables.com/docs/components/tabs" />
 
 A collection of layered content sections, referred to as tab panels, displayed individually.
 

--- a/apps/docs/src/content/docs/toggle-group.mdx
+++ b/apps/docs/src/content/docs/toggle-group.mdx
@@ -13,6 +13,9 @@ import importedNativeCode from '@/../node_modules/@rn-primitives/toggle-group/sr
 import importedWebCode from '@/../node_modules/@rn-primitives/toggle-group/src/toggle-group.web.tsx?raw';
 import importedTypesCode from '@/../node_modules/@rn-primitives/toggle-group/src/types.ts?raw';
 import importedIndexCode from '@/../node_modules/@rn-primitives/toggle-group/src/index.ts?raw';
+import ReusablesBadge from '@/components/ReusablesBadge.astro';
+
+<ReusablesBadge href="https://reactnativereusables.com/docs/components/toggle-group" />
 
 A collection of buttons with true or false states, which can be activated or deactivated by toggling.
 

--- a/apps/docs/src/content/docs/toggle.mdx
+++ b/apps/docs/src/content/docs/toggle.mdx
@@ -13,6 +13,9 @@ import importedNativeCode from '@/../node_modules/@rn-primitives/toggle/src/togg
 import importedWebCode from '@/../node_modules/@rn-primitives/toggle/src/toggle.web.tsx?raw';
 import importedTypesCode from '@/../node_modules/@rn-primitives/toggle/src/types.ts?raw';
 import importedIndexCode from '@/../node_modules/@rn-primitives/toggle/src/index.ts?raw';
+import ReusablesBadge from '@/components/ReusablesBadge.astro';
+
+<ReusablesBadge href="https://reactnativereusables.com/docs/components/toggle" />
 
 A button with a true or false state, which can be activated or deactivated by toggling.
 

--- a/apps/docs/src/content/docs/tooltip.mdx
+++ b/apps/docs/src/content/docs/tooltip.mdx
@@ -13,6 +13,9 @@ import importedNativeCode from '@/../node_modules/@rn-primitives/tooltip/src/too
 import importedWebCode from '@/../node_modules/@rn-primitives/tooltip/src/tooltip.web.tsx?raw';
 import importedTypesCode from '@/../node_modules/@rn-primitives/tooltip/src/types.ts?raw';
 import importedIndexCode from '@/../node_modules/@rn-primitives/tooltip/src/index.ts?raw';
+import ReusablesBadge from '@/components/ReusablesBadge.astro';
+
+<ReusablesBadge href="https://reactnativereusables.com/docs/components/tooltip" />
 
 A pop-up presenting relevant information pertaining to an element whenever the element gains keyboard focus or when the mouse hovers over it.
 

--- a/apps/docs/src/styles/theme.css
+++ b/apps/docs/src/styles/theme.css
@@ -1,0 +1,833 @@
+/* ---------------------------------------------------------------------------
+   rn-primitives docs theme
+   Zinc neutrals + violet accent (a nod to the Radix heritage).
+   Dark is the default Starlight theme; light overrides below.
+--------------------------------------------------------------------------- */
+
+:root {
+  /* Typography */
+  --sl-font: 'Inter Variable', ui-sans-serif, system-ui, sans-serif;
+  --sl-font-mono: 'JetBrains Mono Variable', ui-monospace, 'SF Mono', Menlo, monospace;
+
+  /* Accent — violet */
+  --sl-color-accent-low: #2a2153;
+  --sl-color-accent: #7c66dc;
+  --sl-color-accent-high: #c9bdf9;
+
+  /* Grays — zinc-leaning */
+  --sl-color-white: #fafafa;
+  --sl-color-gray-1: #e9e9ec;
+  --sl-color-gray-2: #b6b6bf;
+  --sl-color-gray-3: #898992;
+  --sl-color-gray-4: #4e4e57;
+  --sl-color-gray-5: #27272c;
+  --sl-color-gray-6: #17171a;
+  --sl-color-black: #0c0c0e;
+
+  --sl-color-bg: var(--sl-color-black);
+  --sl-color-bg-nav: var(--sl-color-bg);
+  --sl-color-bg-sidebar: var(--sl-color-bg);
+  --sl-color-bg-inline-code: #1c1c21;
+  --sl-color-hairline-light: #232329;
+  --sl-color-hairline: #1e1e24;
+  --sl-color-hairline-shade: #141418;
+
+  --sl-color-text-accent: var(--sl-color-accent-high);
+
+  --sl-content-width: 46rem;
+  --sl-text-code: 0.8125rem;
+  --sl-text-code-sm: 0.75rem;
+
+  /* Heading sizes — set via Starlight's variables (not raw font-size on the
+     heading elements) so the anchor-link icon math uses the same size. */
+  --sl-text-h2: 1.375rem;
+  --sl-text-h3: 1.0625rem;
+  --sl-text-h4: 1rem;
+  --sl-text-h5: 0.9375rem;
+
+  --rnp-glow: radial-gradient(ellipse 80% 50% at 50% -20%, rgba(124, 102, 220, 0.15), transparent);
+  --rnp-card-bg: rgba(255, 255, 255, 0.02);
+  --rnp-card-bg-hover: rgba(255, 255, 255, 0.045);
+}
+
+:root[data-theme='light'] {
+  --sl-color-accent-low: #ece8fd;
+  --sl-color-accent: #6550b9;
+  --sl-color-accent-high: #4c3d99;
+
+  --sl-color-white: #17171b;
+  --sl-color-gray-1: #26262b;
+  --sl-color-gray-2: #43434b;
+  --sl-color-gray-3: #6b6b76;
+  --sl-color-gray-4: #9c9ca6;
+  --sl-color-gray-5: #d9d9df;
+  --sl-color-gray-6: #f2f2f5;
+  --sl-color-gray-7: #f8f8fa;
+  --sl-color-black: #ffffff;
+
+  --sl-color-bg: var(--sl-color-black);
+  --sl-color-bg-nav: var(--sl-color-bg);
+  --sl-color-bg-sidebar: var(--sl-color-bg);
+  --sl-color-bg-inline-code: #f1f0f6;
+  --sl-color-hairline-light: #e7e7ec;
+  --sl-color-hairline: #e9e9ee;
+  --sl-color-hairline-shade: #f0f0f3;
+
+  --sl-color-text-accent: var(--sl-color-accent);
+
+  --rnp-glow: radial-gradient(ellipse 80% 50% at 50% -20%, rgba(101, 80, 185, 0.09), transparent);
+  --rnp-card-bg: rgba(23, 23, 27, 0.015);
+  --rnp-card-bg-hover: rgba(23, 23, 27, 0.04);
+}
+
+/* ---------------------------------------------------------------------------
+   Base
+--------------------------------------------------------------------------- */
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: 'cv11', 'ss01';
+}
+
+::selection {
+  background: color-mix(in srgb, var(--sl-color-accent) 30%, transparent);
+}
+
+/* Thin, unobtrusive scrollbars for inner panes */
+.sidebar-pane ::-webkit-scrollbar,
+.right-sidebar ::-webkit-scrollbar {
+  width: 6px;
+}
+.sidebar-pane ::-webkit-scrollbar-thumb,
+.right-sidebar ::-webkit-scrollbar-thumb {
+  background: var(--sl-color-gray-5);
+  border-radius: 9999px;
+}
+.sidebar-pane ::-webkit-scrollbar-track,
+.right-sidebar ::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+/* ---------------------------------------------------------------------------
+   Header
+--------------------------------------------------------------------------- */
+
+.header {
+  background-color: var(--sl-color-bg);
+}
+
+.site-title {
+  font-weight: 640;
+  font-size: var(--sl-text-lg);
+  letter-spacing: -0.02em;
+  color: var(--sl-color-white);
+  gap: 0.75rem;
+}
+
+.site-title img {
+  height: 1.25rem;
+  width: auto;
+}
+
+.social-icons a {
+  color: var(--sl-color-gray-3);
+  transition: color 0.15s ease;
+}
+.social-icons a:hover {
+  color: var(--sl-color-white);
+  opacity: 1;
+}
+
+/* Search button */
+site-search button[data-open-modal] {
+  border: 1px solid var(--sl-color-hairline-light);
+  border-radius: 0.625rem;
+  background-color: var(--rnp-card-bg);
+  color: var(--sl-color-gray-3);
+  font-size: var(--sl-text-sm);
+  padding-inline-start: 0.75rem;
+  padding-inline-end: 0.5rem;
+  height: 2.25rem;
+  gap: 0.5rem;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+site-search button[data-open-modal]:hover {
+  border-color: var(--sl-color-gray-4);
+  background-color: var(--rnp-card-bg-hover);
+  color: var(--sl-color-gray-2);
+}
+site-search button[data-open-modal] kbd {
+  background-color: var(--sl-color-gray-6);
+  border: 1px solid var(--sl-color-hairline-light);
+  border-radius: 0.375rem;
+  font-family: var(--sl-font-mono);
+  font-size: 0.6875rem;
+  color: var(--sl-color-gray-3);
+  padding-inline: 0.375rem;
+}
+
+/* Mobile menu button */
+starlight-menu-button button {
+  background-color: transparent;
+  border: 1px solid var(--sl-color-hairline-light);
+  border-radius: 0.5rem;
+  color: var(--sl-color-gray-2);
+  box-shadow: none;
+}
+starlight-menu-button[aria-expanded='true'] button {
+  background-color: var(--sl-color-gray-5);
+  color: var(--sl-color-white);
+}
+
+/* ---------------------------------------------------------------------------
+   Sidebar
+--------------------------------------------------------------------------- */
+
+.sidebar-pane {
+  border-inline-end: 1px solid var(--sl-color-hairline);
+  background-color: var(--sl-color-bg-sidebar);
+}
+
+.sidebar-content {
+  padding-block: 1.25rem;
+}
+
+.sidebar-content summary {
+  padding-inline-start: 0.5rem;
+}
+
+/* Group labels */
+.sidebar-content .group-label span.large {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--sl-color-gray-3);
+}
+
+/* Links */
+.sidebar-content a {
+  border-radius: 0.5rem;
+  font-size: 0.84375rem;
+  font-weight: 450;
+  color: var(--sl-color-gray-2);
+  padding: 0.3125rem 0.625rem;
+  margin-block: 1px;
+  transition:
+    color 0.12s ease,
+    background-color 0.12s ease;
+}
+
+.sidebar-content a:hover {
+  color: var(--sl-color-white);
+  background-color: var(--rnp-card-bg-hover);
+}
+
+.sidebar-content a[aria-current='page'],
+.sidebar-content a[aria-current='page']:hover {
+  background-color: color-mix(in srgb, var(--sl-color-accent) 14%, transparent);
+  color: var(--sl-color-text-accent);
+  font-weight: 550;
+}
+
+/* ---------------------------------------------------------------------------
+   Right sidebar — table of contents
+--------------------------------------------------------------------------- */
+
+.right-sidebar {
+  border-inline-start: 1px solid var(--sl-color-hairline);
+}
+
+starlight-toc h2 {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--sl-color-gray-3);
+}
+
+starlight-toc a {
+  font-size: 0.8125rem;
+  color: var(--sl-color-gray-3);
+  transition: color 0.12s ease;
+}
+starlight-toc a:hover {
+  color: var(--sl-color-white);
+}
+starlight-toc a[aria-current='true'] {
+  color: var(--sl-color-text-accent);
+  font-weight: 500;
+  background-color: transparent;
+}
+
+/* ---------------------------------------------------------------------------
+   Markdown content
+--------------------------------------------------------------------------- */
+
+.sl-markdown-content {
+  font-size: 0.9375rem;
+  line-height: 1.75;
+  color: var(--sl-color-gray-2);
+}
+
+.sl-markdown-content :is(h1, h2, h3, h4, h5, h6) {
+  color: var(--sl-color-white);
+  letter-spacing: -0.02em;
+  font-weight: 600;
+}
+
+.sl-markdown-content h1 {
+  font-size: 2rem;
+  letter-spacing: -0.03em;
+  font-weight: 650;
+}
+
+.sl-markdown-content .sl-heading-wrapper.level-h2:not(:where(.not-content *)) {
+  margin-top: 3rem;
+  padding-top: 1.75rem;
+  border-top: 1px solid var(--sl-color-hairline);
+}
+
+.sl-markdown-content .sl-heading-wrapper.level-h3:not(:where(.not-content *)) {
+  margin-top: 2rem;
+}
+
+/* Page intro line under h1 */
+.content-panel h1 + p {
+  color: var(--sl-color-gray-3);
+}
+
+/* Heading anchor link — tune Starlight's own icon-size/gap variables so its
+   padding + negative-margin placement and vertical centering stay intact. */
+.sl-markdown-content .sl-heading-wrapper {
+  --sl-anchor-icon-size: 0.75em;
+  --sl-anchor-icon-gap: 0.375em;
+}
+
+.sl-markdown-content .sl-anchor-link {
+  color: var(--sl-color-gray-4);
+}
+
+.sl-markdown-content .sl-anchor-link:hover,
+.sl-markdown-content .sl-anchor-link:focus {
+  color: var(--sl-color-text-accent);
+}
+
+/* Links */
+.sl-markdown-content a:not(:where(.not-content *)) {
+  color: var(--sl-color-text-accent);
+  font-weight: 500;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--sl-color-accent) 40%, transparent);
+  text-underline-offset: 3px;
+  transition: text-decoration-color 0.12s ease;
+}
+.sl-markdown-content a:not(:where(.not-content *)):hover {
+  color: var(--sl-color-white);
+  text-decoration-color: var(--sl-color-accent);
+}
+
+/* Inline code */
+.sl-markdown-content code:not(:where(.not-content *, pre *)) {
+  background-color: var(--sl-color-bg-inline-code);
+  border: 1px solid var(--sl-color-hairline-light);
+  border-radius: 0.375rem;
+  font-size: 0.8125em;
+  padding: 0.125rem 0.375rem;
+  color: var(--sl-color-gray-1);
+}
+
+/* ---------------------------------------------------------------------------
+   React Native Reusables badge
+--------------------------------------------------------------------------- */
+
+a.rnp-reusables-badge {
+  display: flex;
+  width: fit-content;
+  align-items: center;
+  gap: 0.4375rem;
+  border: 1px solid var(--sl-color-hairline-light);
+  border-radius: 0.625rem;
+  background-color: var(--rnp-card-bg);
+  padding: 0.3125rem 0.75rem;
+  font-size: 0.78125rem;
+  font-weight: 450;
+  color: var(--sl-color-gray-3);
+  text-decoration: none;
+  margin-bottom: 2rem;
+  transition:
+    border-color 0.15s ease,
+    color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+/* Pull the badge up directly under the page title: the title panel's own
+   bottom padding (1.5rem) becomes the gap, matching the badge's bottom margin. */
+.content-panel:has(.sl-markdown-content > a.rnp-reusables-badge:first-child) {
+  padding-top: 0;
+}
+
+a.rnp-reusables-badge strong {
+  font-weight: 400;
+  color: var(--sl-color-gray-2);
+  transition: color 0.15s ease;
+}
+
+a.rnp-reusables-badge svg:first-child {
+  color: var(--sl-color-text-accent);
+}
+
+a.rnp-reusables-badge svg:last-child {
+  color: var(--sl-color-gray-4);
+  transition:
+    color 0.15s ease,
+    transform 0.15s ease;
+}
+
+a.rnp-reusables-badge:hover {
+  border-color: color-mix(in srgb, var(--sl-color-accent) 50%, transparent);
+  background-color: var(--rnp-card-bg-hover);
+  color: var(--sl-color-gray-2);
+}
+
+a.rnp-reusables-badge:hover strong {
+  color: var(--sl-color-white);
+}
+
+a.rnp-reusables-badge:hover svg:last-child {
+  color: var(--sl-color-text-accent);
+  transform: translate(1px, -1px);
+}
+
+/* ---------------------------------------------------------------------------
+   Tables (prop tables)
+--------------------------------------------------------------------------- */
+
+.sl-markdown-content table:not(:where(.not-content *)) {
+  display: table;
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border: 1px solid var(--sl-color-hairline-light);
+  border-radius: 0.75rem;
+  overflow: hidden;
+  font-size: 0.84375rem;
+  margin-block: 1.25rem;
+}
+
+.sl-markdown-content table :is(th, td):not(:where(.not-content *)) {
+  text-align: left !important;
+  padding: 0.625rem 1rem;
+  border: none;
+  border-bottom: 1px solid var(--sl-color-hairline-light);
+}
+
+.sl-markdown-content thead th:not(:where(.not-content *)) {
+  background-color: color-mix(in srgb, var(--sl-color-gray-6) 70%, var(--sl-color-bg));
+  color: var(--sl-color-gray-3);
+  font-size: 0.75rem;
+  font-weight: 550;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.sl-markdown-content tr:last-child td:not(:where(.not-content *)) {
+  border-bottom: none;
+}
+
+.sl-markdown-content tbody tr:nth-child(2n):not(:where(.not-content *)) {
+  background-color: transparent;
+}
+
+.sl-markdown-content tbody tr:hover:not(:where(.not-content *)) {
+  background-color: var(--rnp-card-bg);
+}
+
+/* Prop names read as code */
+.sl-markdown-content tbody td:first-child:not(:where(.not-content *)) {
+  font-family: var(--sl-font-mono);
+  font-size: 0.78125rem;
+  color: var(--sl-color-white);
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.sl-markdown-content tbody td:nth-child(2):not(:where(.not-content *)) {
+  font-family: var(--sl-font-mono);
+  font-size: 0.78125rem;
+  color: var(--sl-color-text-accent);
+}
+
+.sl-markdown-content tbody td:nth-child(3):not(:where(.not-content *)) {
+  color: var(--sl-color-gray-3);
+}
+
+/* ---------------------------------------------------------------------------
+   Asides
+--------------------------------------------------------------------------- */
+
+.starlight-aside {
+  border: 1px solid;
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  background-clip: padding-box;
+}
+
+.starlight-aside__title {
+  font-size: 0.84375rem;
+  font-weight: 600;
+}
+
+.starlight-aside__content {
+  font-size: 0.875rem;
+}
+
+.starlight-aside--note {
+  border-color: color-mix(in srgb, var(--sl-color-accent) 30%, transparent);
+  background-color: color-mix(in srgb, var(--sl-color-accent) 8%, transparent);
+  color: var(--sl-color-gray-2);
+}
+.starlight-aside--note .starlight-aside__title {
+  color: var(--sl-color-text-accent);
+}
+
+.starlight-aside--tip {
+  border-color: color-mix(in srgb, #34d399 25%, transparent);
+  background-color: color-mix(in srgb, #34d399 7%, transparent);
+  color: var(--sl-color-gray-2);
+}
+.starlight-aside--tip .starlight-aside__title {
+  color: #34d399;
+}
+:root[data-theme='light'] .starlight-aside--tip .starlight-aside__title {
+  color: #047857;
+}
+
+.starlight-aside--caution {
+  border-color: color-mix(in srgb, #fbbf24 25%, transparent);
+  background-color: color-mix(in srgb, #fbbf24 7%, transparent);
+  color: var(--sl-color-gray-2);
+}
+.starlight-aside--caution .starlight-aside__title {
+  color: #fbbf24;
+}
+:root[data-theme='light'] .starlight-aside--caution .starlight-aside__title {
+  color: #b45309;
+}
+
+.starlight-aside--danger {
+  border-color: color-mix(in srgb, #f87171 25%, transparent);
+  background-color: color-mix(in srgb, #f87171 7%, transparent);
+  color: var(--sl-color-gray-2);
+}
+.starlight-aside--danger .starlight-aside__title {
+  color: #f87171;
+}
+:root[data-theme='light'] .starlight-aside--danger .starlight-aside__title {
+  color: #b91c1c;
+}
+
+/* ---------------------------------------------------------------------------
+   Tabs — segmented control style
+--------------------------------------------------------------------------- */
+
+starlight-tabs .tablist-wrapper {
+  overflow-x: auto;
+}
+
+starlight-tabs [role='tablist'] {
+  display: inline-flex;
+  border: 1px solid var(--sl-color-hairline-light);
+  border-radius: 0.625rem;
+  background-color: color-mix(in srgb, var(--sl-color-gray-6) 60%, var(--sl-color-bg));
+  padding: 0.25rem;
+  gap: 0.25rem;
+  border-bottom: 1px solid var(--sl-color-hairline-light);
+}
+
+starlight-tabs .tab {
+  margin-bottom: 0;
+}
+
+starlight-tabs .tab > [role='tab'] {
+  border: none;
+  border-radius: 0.4375rem;
+  padding: 0.3125rem 0.875rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--sl-color-gray-3);
+  transition:
+    color 0.12s ease,
+    background-color 0.12s ease;
+}
+
+starlight-tabs .tab > [role='tab']:hover {
+  color: var(--sl-color-white);
+}
+
+starlight-tabs .tab > [role='tab'][aria-selected='true'] {
+  background-color: var(--sl-color-bg);
+  color: var(--sl-color-white);
+  border: none;
+  font-weight: 550;
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.25),
+    inset 0 0 0 1px var(--sl-color-hairline-light);
+}
+
+:root[data-theme='light'] starlight-tabs .tab > [role='tab'][aria-selected='true'] {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.08),
+    inset 0 0 0 1px var(--sl-color-hairline-light);
+}
+
+/* ---------------------------------------------------------------------------
+   Code blocks (Expressive Code)
+--------------------------------------------------------------------------- */
+
+.expressive-code {
+  margin-block: 1.25rem;
+}
+
+.expressive-code .copy button {
+  opacity: 1 !important;
+}
+
+/* ---------------------------------------------------------------------------
+   Pagination (prev / next)
+--------------------------------------------------------------------------- */
+
+.pagination-links a {
+  border: 1px solid var(--sl-color-hairline-light);
+  border-radius: 0.75rem;
+  background-color: var(--rnp-card-bg);
+  box-shadow: none;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+.pagination-links a:hover {
+  border-color: color-mix(in srgb, var(--sl-color-accent) 45%, transparent);
+  background-color: var(--rnp-card-bg-hover);
+}
+.pagination-links a .link-title {
+  font-size: 1.0625rem;
+  letter-spacing: -0.01em;
+  color: var(--sl-color-white);
+}
+
+/* ---------------------------------------------------------------------------
+   Search modal (Pagefind)
+--------------------------------------------------------------------------- */
+
+dialog[aria-label='Search'] {
+  border: 1px solid var(--sl-color-hairline-light);
+  border-radius: 1rem;
+  background-color: var(--sl-color-bg);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.45);
+}
+dialog[aria-label='Search']::backdrop {
+  background-color: color-mix(in srgb, var(--sl-color-black) 60%, transparent);
+  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px);
+}
+
+/* ---------------------------------------------------------------------------
+   Landing page (splash)
+--------------------------------------------------------------------------- */
+
+[data-has-hero] {
+  --sl-content-width: 68rem;
+}
+
+/* The glow overlays the page from its very top edge (including the header)
+   so the fixed header doesn't slice it. It is purely decorative light, so it
+   paints above the header, ignores pointer events, and scrolls away with the
+   page. */
+[data-has-hero] .page {
+  position: relative;
+}
+
+[data-has-hero] .page::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 44rem;
+  background-image: var(--rnp-glow);
+  background-repeat: no-repeat;
+  pointer-events: none;
+  z-index: calc(var(--sl-z-index-navbar, 10) + 1);
+}
+
+[data-has-hero] .hero {
+  padding-block: 4rem 2rem;
+}
+
+[data-has-hero] .hero h1 {
+  font-size: clamp(2.5rem, 5vw, 3.75rem);
+  font-weight: 700;
+  letter-spacing: -0.035em;
+  line-height: 1.05;
+  background: linear-gradient(
+    180deg,
+    var(--sl-color-white) 30%,
+    color-mix(in srgb, var(--sl-color-white) 55%, var(--sl-color-accent))
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+
+[data-has-hero] .hero .tagline {
+  font-size: 1.125rem;
+  line-height: 1.7;
+  color: var(--sl-color-gray-3);
+  max-width: 40rem;
+}
+
+/* Hero action buttons */
+[data-has-hero] .hero .sl-link-button {
+  border-radius: 0.625rem;
+  font-size: 0.9375rem;
+  font-weight: 550;
+  padding: 0.625rem 1.25rem;
+  transition:
+    opacity 0.15s ease,
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+[data-has-hero] .hero .sl-link-button.primary {
+  background-color: var(--sl-color-white);
+  border-color: var(--sl-color-white);
+  color: var(--sl-color-black);
+}
+[data-has-hero] .hero .sl-link-button.primary:hover {
+  opacity: 0.85;
+}
+[data-has-hero] .hero .sl-link-button.secondary,
+[data-has-hero] .hero .sl-link-button.minimal {
+  border: 1px solid var(--sl-color-hairline-light);
+  background-color: var(--rnp-card-bg);
+  color: var(--sl-color-white);
+}
+[data-has-hero] .hero .sl-link-button.secondary:hover,
+[data-has-hero] .hero .sl-link-button.minimal:hover {
+  border-color: var(--sl-color-gray-4);
+  background-color: var(--rnp-card-bg-hover);
+}
+
+/* Landing sections */
+.rnp-section-title {
+  font-size: 0.75rem !important;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--sl-color-gray-3) !important;
+  margin-top: 3.5rem !important;
+  border: none !important;
+  padding-top: 0 !important;
+}
+
+/* Feature grid */
+.rnp-features {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 0.875rem;
+  margin-top: 1.25rem;
+}
+
+.rnp-feature {
+  border: 1px solid var(--sl-color-hairline-light);
+  border-radius: 0.875rem;
+  background-color: var(--rnp-card-bg);
+  padding: 1.25rem;
+}
+
+.rnp-feature svg {
+  color: var(--sl-color-text-accent);
+  margin-bottom: 0.75rem;
+}
+
+.rnp-feature h3 {
+  font-size: 0.9375rem !important;
+  font-weight: 600;
+  margin: 0 0 0.375rem !important;
+  color: var(--sl-color-white);
+}
+
+.rnp-feature p {
+  font-size: 0.84375rem;
+  line-height: 1.6;
+  color: var(--sl-color-gray-3);
+  margin: 0;
+}
+
+/* Primitive card grid */
+.rnp-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(13.5rem, 1fr));
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+.rnp-card {
+  position: relative;
+  display: block;
+  border: 1px solid var(--sl-color-hairline-light);
+  border-radius: 0.75rem;
+  background-color: var(--rnp-card-bg);
+  padding: 1rem 1.125rem;
+  text-decoration: none !important;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease,
+    transform 0.15s ease;
+}
+
+.rnp-card:hover {
+  border-color: color-mix(in srgb, var(--sl-color-accent) 50%, transparent);
+  background-color: var(--rnp-card-bg-hover);
+  transform: translateY(-1px);
+}
+
+.rnp-card-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--sl-color-white);
+  letter-spacing: -0.01em;
+}
+
+.rnp-card-title::after {
+  content: '→';
+  font-size: 0.8125rem;
+  color: var(--sl-color-gray-4);
+  transition:
+    color 0.15s ease,
+    transform 0.15s ease;
+}
+
+.rnp-card:hover .rnp-card-title::after {
+  color: var(--sl-color-text-accent);
+  transform: translateX(2px);
+}
+
+.rnp-card-desc {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 0.78125rem;
+  line-height: 1.55;
+  color: var(--sl-color-gray-3);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,12 @@ importers:
       '@astrojs/tailwind':
         specifier: ^5.1.0
         version: 5.1.5(astro@5.18.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(rollup@4.59.0)(terser@5.46.0)(typescript@5.9.3)(yaml@2.8.2))(tailwindcss@3.4.19(yaml@2.8.2))
+      '@fontsource-variable/inter':
+        specifier: ^5.2.8
+        version: 5.2.8
+      '@fontsource-variable/jetbrains-mono':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@radix-ui/react-collapsible':
         specifier: ^1.1.12
         version: 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -2959,6 +2965,12 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@fontsource-variable/inter@5.2.8':
+    resolution: {integrity: sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==}
+
+  '@fontsource-variable/jetbrains-mono@5.2.8':
+    resolution: {integrity: sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -4368,6 +4380,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -4525,6 +4538,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -8797,6 +8811,7 @@ packages:
 
   uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   validate-npm-package-name@5.0.1:
@@ -10775,6 +10790,10 @@ snapshots:
       react-dom: 19.2.4(react@19.2.0)
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource-variable/inter@5.2.8': {}
+
+  '@fontsource-variable/jetbrains-mono@5.2.8': {}
 
   '@humanfs/core@0.19.1': {}
 


### PR DESCRIPTION
- Added new logo assets for dark and light themes.
- Introduced a new ReusablesBadge component for linking to React Native Reusables documentation.
- Updated astro.config.mjs to include new font sources and site metadata.
- Enhanced the main documentation index with a PrimitiveGrid for better navigation.
- Updated theme styles in theme.css to support new typography and color schemes.
- Added new dependencies for variable fonts in package.json and pnpm-lock.yaml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the docs homepage with a new grid-based layout and clearer feature highlights.
  * Added links from many docs pages to related React Native Reusables pages for easier navigation.

* **Documentation**
  * Expanded the `Slot` docs with clearer usage guidance, examples, and deprecation notes.
  * Improved the docs site branding, typography, code presentation, and overall visual polish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->