### PR TITLE
feat: add useRestoreAccessibilityFocus hook and integrate into various components

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/accordion",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive accordion",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/alert-dialog/package.json
+++ b/packages/alert-dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/alert-dialog",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive alert dialog",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/alert-dialog/src/alert-dialog.tsx
+++ b/packages/alert-dialog/src/alert-dialog.tsx
@@ -2,6 +2,7 @@ import {
   useAccessibilityFocus,
   useComposedRefs,
   useControllableState,
+  useRestoreAccessibilityFocus,
 } from '@rn-primitives/hooks';
 import { Portal as RNPPortal } from '@rn-primitives/portal';
 import { Slot } from '@rn-primitives/slot';
@@ -80,6 +81,9 @@ const Trigger = ({
   ...props
 }: TriggerComponentProps) => {
   const { open: value, onOpenChange } = useRootContext();
+  const triggerRef = React.useRef<TriggerRef>(null);
+  const composedRef = useComposedRefs(ref, triggerRef);
+  useRestoreAccessibilityFocus(value, triggerRef);
 
   function onPress(ev: GestureResponderEvent) {
     onOpenChange(!value);
@@ -89,7 +93,7 @@ const Trigger = ({
   const Component = asChild ? Slot : Pressable;
   return (
     <Component
-      ref={ref}
+      ref={composedRef}
       aria-disabled={disabled ?? undefined}
       aria-expanded={value}
       role='button'

--- a/packages/aspect-ratio/package.json
+++ b/packages/aspect-ratio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/aspect-ratio",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive aspect ratio",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/avatar",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive avatar",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/checkbox",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive checkbox",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/collapsible/package.json
+++ b/packages/collapsible/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/collapsible",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive collapsible",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/context-menu/package.json
+++ b/packages/context-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/context-menu",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive context menu",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/context-menu/src/context-menu.tsx
+++ b/packages/context-menu/src/context-menu.tsx
@@ -3,6 +3,7 @@ import {
   useComposedRefs,
   useControllableState,
   useEffectEvent,
+  useRestoreAccessibilityFocus,
   useRelativePosition,
   type LayoutPosition,
 } from '@rn-primitives/hooks';
@@ -127,6 +128,7 @@ const Trigger = ({
 }: TriggerComponentProps) => {
   const { open, onOpenChange, relativeTo, setPressPosition } = useRootContext();
   const triggerRef = React.useRef<TriggerRef>(null);
+  useRestoreAccessibilityFocus(open, triggerRef);
 
   function measureTrigger() {
     triggerRef.current?.measure((_x, _y, width, height, pageX, pageY) => {
@@ -609,6 +611,9 @@ const SubTrigger = ({
   ...props
 }: SubTriggerComponentProps) => {
   const { open, onOpenChange } = useSubContext();
+  const triggerRef = React.useRef<SubTriggerRef>(null);
+  const composedRef = useComposedRefs(ref, triggerRef);
+  useRestoreAccessibilityFocus(open, triggerRef);
 
   function onPress(ev: GestureResponderEvent) {
     onOpenChange(!open);
@@ -618,7 +623,7 @@ const SubTrigger = ({
   const Component = asChild ? Slot : Pressable;
   return (
     <Component
-      ref={ref}
+      ref={composedRef}
       aria-label={textValue}
       role='menuitem'
       aria-expanded={open}

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/dialog",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive dialog",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/dialog/src/dialog.tsx
+++ b/packages/dialog/src/dialog.tsx
@@ -2,6 +2,7 @@ import {
   useAccessibilityFocus,
   useComposedRefs,
   useControllableState,
+  useRestoreAccessibilityFocus,
 } from '@rn-primitives/hooks';
 import { Portal as RNPPortal } from '@rn-primitives/portal';
 import { Slot } from '@rn-primitives/slot';
@@ -77,6 +78,9 @@ const Trigger = ({
   ...props
 }: TriggerComponentProps) => {
   const { open, onOpenChange } = useRootContext();
+  const triggerRef = React.useRef<TriggerRef>(null);
+  const composedRef = useComposedRefs(ref, triggerRef);
+  useRestoreAccessibilityFocus(open, triggerRef);
 
   function onPress(ev: GestureResponderEvent) {
     if (disabled) return;
@@ -88,7 +92,7 @@ const Trigger = ({
   const Component = asChild ? Slot : Pressable;
   return (
     <Component
-      ref={ref}
+      ref={composedRef}
       aria-disabled={disabled ?? undefined}
       aria-expanded={open}
       role='button'

--- a/packages/dropdown-menu/package.json
+++ b/packages/dropdown-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/dropdown-menu",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive dropdown menu",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/dropdown-menu/src/dropdown-menu.tsx
+++ b/packages/dropdown-menu/src/dropdown-menu.tsx
@@ -3,6 +3,7 @@ import {
   useComposedRefs,
   useControllableState,
   useEffectEvent,
+  useRestoreAccessibilityFocus,
   useRelativePosition,
   type LayoutPosition,
 } from '@rn-primitives/hooks';
@@ -121,6 +122,7 @@ const Trigger = ({
 }: TriggerComponentProps) => {
   const { open, onOpenChange, setTriggerPosition } = useRootContext();
   const triggerRef = React.useRef<TriggerRef>(null);
+  useRestoreAccessibilityFocus(open, triggerRef);
 
   function measureTrigger() {
     triggerRef.current?.measure((_x, _y, width, height, pageX, pageY) => {
@@ -576,6 +578,9 @@ const SubTrigger = ({
   ...props
 }: SubTriggerComponentProps) => {
   const { open, onOpenChange } = useSubContext();
+  const triggerRef = React.useRef<SubTriggerRef>(null);
+  const composedRef = useComposedRefs(ref, triggerRef);
+  useRestoreAccessibilityFocus(open, triggerRef);
 
   function onPress(ev: GestureResponderEvent) {
     onOpenChange(!open);
@@ -585,7 +590,7 @@ const SubTrigger = ({
   const Component = asChild ? Slot : Pressable;
   return (
     <Component
-      ref={ref}
+      ref={composedRef}
       aria-label={textValue}
       role='menuitem'
       aria-expanded={open}

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/hooks",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive hooks",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,4 +1,5 @@
 export { useAccessibilityFocus } from './useAccessibilityFocus';
+export { useRestoreAccessibilityFocus } from './useRestoreAccessibilityFocus';
 export { useAugmentedRef } from './useAugmentedRef';
 export { useRelativePosition, type LayoutPosition } from './useRelativePosition';
 export { useControllableState } from './useControllableState';

--- a/packages/hooks/src/useRestoreAccessibilityFocus.tsx
+++ b/packages/hooks/src/useRestoreAccessibilityFocus.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { AccessibilityInfo, findNodeHandle, Platform } from 'react-native';
+
+/**
+ * Restores screen-reader focus to `ref` when `open` transitions from
+ * true -> false. Pairs with useAccessibilityFocus, which moves focus INTO
+ * content on open but never restores it on close, leaving VoiceOver/TalkBack
+ * focus stranded on the root view after the overlay unmounts.
+ */
+export function useRestoreAccessibilityFocus(open: boolean, ref: React.RefObject<unknown>) {
+  const wasOpenRef = React.useRef(open);
+  React.useEffect(() => {
+    const wasOpen = wasOpenRef.current;
+    wasOpenRef.current = open;
+    if (Platform.OS === 'web' || !wasOpen || open) {
+      return;
+    }
+    const node = ref.current ? findNodeHandle(ref.current as any) : null;
+    if (node == null) {
+      return;
+    }
+    // Let the content finish unmounting before moving focus back.
+    const timeout = setTimeout(() => AccessibilityInfo.setAccessibilityFocus(node), 50);
+    return () => clearTimeout(timeout);
+  }, [open, ref]);
+}

--- a/packages/hover-card/package.json
+++ b/packages/hover-card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/hover-card",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive hover card",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/hover-card/src/hover-card.tsx
+++ b/packages/hover-card/src/hover-card.tsx
@@ -3,6 +3,7 @@ import {
   useComposedRefs,
   useEffectEvent,
   useRelativePosition,
+  useRestoreAccessibilityFocus,
   type LayoutPosition,
 } from '@rn-primitives/hooks';
 import { Portal as RNPPortal } from '@rn-primitives/portal';
@@ -100,6 +101,7 @@ const Trigger = ({
 }: TriggerComponentProps) => {
   const { open, onOpenChange, setTriggerPosition } = useRootContext();
   const triggerRef = React.useRef<TriggerRef>(null);
+  useRestoreAccessibilityFocus(open, triggerRef);
 
   function measureTrigger() {
     triggerRef.current?.measure((_x, _y, width, height, pageX, pageY) => {

--- a/packages/label/package.json
+++ b/packages/label/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/label",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive label",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/menubar/package.json
+++ b/packages/menubar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/menubar",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive menubar",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/menubar/src/menubar.tsx
+++ b/packages/menubar/src/menubar.tsx
@@ -3,6 +3,7 @@ import {
   useComposedRefs,
   useControllableState,
   useRelativePosition,
+  useRestoreAccessibilityFocus,
   type LayoutPosition,
 } from '@rn-primitives/hooks';
 import { Portal as RNPPortal } from '@rn-primitives/portal';
@@ -135,6 +136,7 @@ const Trigger = ({
   const composedRef = useComposedRefs(ref, triggerRef);
   const { value, onValueChange, setTriggerPosition } = useRootContext();
   const { value: menuValue } = useMenuContext();
+  useRestoreAccessibilityFocus(value === menuValue, triggerRef);
 
   function onPress(ev: GestureResponderEvent) {
     if (disabled) return;
@@ -578,6 +580,9 @@ const SubTrigger = ({
   ...props
 }: SubTriggerComponentProps) => {
   const { open, onOpenChange } = useSubContext();
+  const triggerRef = React.useRef<SubTriggerRef>(null);
+  const composedRef = useComposedRefs(ref, triggerRef);
+  useRestoreAccessibilityFocus(open, triggerRef);
 
   function onPress(ev: GestureResponderEvent) {
     onOpenChange(!open);
@@ -587,7 +592,7 @@ const SubTrigger = ({
   const Component = asChild ? Slot : Pressable;
   return (
     <Component
-      ref={ref}
+      ref={composedRef}
       aria-label={textValue}
       role='menuitem'
       aria-expanded={open}

--- a/packages/navigation-menu/package.json
+++ b/packages/navigation-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/navigation-menu",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive navigation menu",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/navigation-menu/src/navigation-menu.tsx
+++ b/packages/navigation-menu/src/navigation-menu.tsx
@@ -2,6 +2,7 @@ import {
   useAccessibilityFocus,
   useComposedRefs,
   useRelativePosition,
+  useRestoreAccessibilityFocus,
   type LayoutPosition,
 } from '@rn-primitives/hooks';
 import { Portal as RNPPortal } from '@rn-primitives/portal';
@@ -129,6 +130,7 @@ const Trigger = ({
   const { value, onValueChange, setTriggerPosition } = useRootContext();
   const { value: menuValue } = useItemContext();
   const composedRef = useComposedRefs(ref, triggerRef);
+  useRestoreAccessibilityFocus(value === menuValue, triggerRef);
 
   function onPress(ev: GestureResponderEvent) {
     if (disabled) return;

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/popover",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive popover",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/popover/src/popover.tsx
+++ b/packages/popover/src/popover.tsx
@@ -3,6 +3,7 @@ import {
   useComposedRefs,
   useEffectEvent,
   useRelativePosition,
+  useRestoreAccessibilityFocus,
   type LayoutPosition,
 } from '@rn-primitives/hooks';
 import { Portal as RNPPortal } from '@rn-primitives/portal';
@@ -97,6 +98,7 @@ const Trigger = ({
 }: TriggerComponentProps) => {
   const { onOpenChange, open, setTriggerPosition } = useRootContext();
   const triggerRef = React.useRef<TriggerRef>(null);
+  useRestoreAccessibilityFocus(open, triggerRef);
 
   function measureTrigger() {
     triggerRef.current?.measure((_x, _y, width, height, pageX, pageY) => {

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/portal",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive portal",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/progress/package.json
+++ b/packages/progress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/progress",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive progress",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/radio-group",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive radio group",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/select",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive select",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/select/src/select.tsx
+++ b/packages/select/src/select.tsx
@@ -4,6 +4,7 @@ import {
   useControllableState,
   useEffectEvent,
   useRelativePosition,
+  useRestoreAccessibilityFocus,
   type LayoutPosition,
 } from '@rn-primitives/hooks';
 import { Portal as RNPPortal } from '@rn-primitives/portal';
@@ -127,6 +128,7 @@ const Trigger = ({
 }: TriggerComponentProps) => {
   const { open, onOpenChange, disabled: disabledRoot, setTriggerPosition } = useRootContext();
   const triggerRef = React.useRef<TriggerRef>(null);
+  useRestoreAccessibilityFocus(open, triggerRef);
 
   function measureTrigger() {
     triggerRef.current?.measure((_x, _y, width, height, pageX, pageY) => {

--- a/packages/separator/package.json
+++ b/packages/separator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/separator",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive separator",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/slider",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive slider",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/slot/package.json
+++ b/packages/slot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/slot",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive slot",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/switch",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive switch",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/table",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive table",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/tabs",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive tabs",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/toast",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive toast",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/toggle-group/package.json
+++ b/packages/toggle-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/toggle-group",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive toggle group",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/toggle/package.json
+++ b/packages/toggle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/toggle",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive toggle",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/toolbar/package.json
+++ b/packages/toolbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/toolbar",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive toolbar",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/tooltip",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive tooltip",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/tooltip/src/tooltip.tsx
+++ b/packages/tooltip/src/tooltip.tsx
@@ -3,6 +3,7 @@ import {
   useComposedRefs,
   useEffectEvent,
   useRelativePosition,
+  useRestoreAccessibilityFocus,
   type LayoutPosition,
 } from '@rn-primitives/hooks';
 import { Portal as RNPPortal } from '@rn-primitives/portal';
@@ -98,6 +99,7 @@ const Trigger = ({
 }: TriggerComponentProps) => {
   const { open, onOpenChange, setTriggerPosition } = useTooltipContext();
   const triggerRef = React.useRef<TriggerRef>(null);
+  useRestoreAccessibilityFocus(open, triggerRef);
 
   function measureTrigger() {
     triggerRef.current?.measure((_x, _y, width, height, pageX, pageY) => {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/types",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive types",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rn-primitives/utils",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Primitive types",
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
This pull request introduces a new accessibility improvement across multiple primitives by adding a custom hook to restore screen-reader focus to the trigger element when overlays (such as dialogs and menus) are closed. This ensures better accessibility for users relying on assistive technologies. Additionally, all affected packages have had their patch versions bumped.

**Accessibility improvements:**

* Added a new hook, `useRestoreAccessibilityFocus`, in `@rn-primitives/hooks` to restore screen-reader focus to the trigger element when overlays close. This hook is now exported from the hooks package. [[1]](diffhunk://#diff-4f3f129f262ad71cb5075ec345deb3881a51f702c320564f9d791a0a566df1f3R1-R26) [[2]](diffhunk://#diff-8f5b1b00919ad73be2b5ca223d98e8f84795d6ef29cb4c2d8f00b2dcbe910d4dR2)
* Integrated `useRestoreAccessibilityFocus` into the trigger components of `alert-dialog`, `context-menu`, `dialog`, `dropdown-menu`, and `hover-card` to improve accessibility focus management when these overlays are closed. [[1]](diffhunk://#diff-a4d32f9d0d05961fbd429421bf8c0413815229d71b43896e416dc129f1d7bcf0R5) [[2]](diffhunk://#diff-a4d32f9d0d05961fbd429421bf8c0413815229d71b43896e416dc129f1d7bcf0R84-R86) [[3]](diffhunk://#diff-a4d32f9d0d05961fbd429421bf8c0413815229d71b43896e416dc129f1d7bcf0L92-R96) [[4]](diffhunk://#diff-1578f610d476a66a63740ae68f5ff2274a42db0c551e47517a109680ed2bd787R6) [[5]](diffhunk://#diff-1578f610d476a66a63740ae68f5ff2274a42db0c551e47517a109680ed2bd787R131) [[6]](diffhunk://#diff-1578f610d476a66a63740ae68f5ff2274a42db0c551e47517a109680ed2bd787R614-R616) [[7]](diffhunk://#diff-1578f610d476a66a63740ae68f5ff2274a42db0c551e47517a109680ed2bd787L621-R626) [[8]](diffhunk://#diff-4a2e397cc30e2995321bbba1e41f728f5fd1aabafcf86514b5b444936444af1aR5) [[9]](diffhunk://#diff-4a2e397cc30e2995321bbba1e41f728f5fd1aabafcf86514b5b444936444af1aR81-R83) [[10]](diffhunk://#diff-4a2e397cc30e2995321bbba1e41f728f5fd1aabafcf86514b5b444936444af1aL91-R95) [[11]](diffhunk://#diff-fdb444e742f80d8e0f7d052579599fe07905622c46f45b599d42556380d52af9R6) [[12]](diffhunk://#diff-fdb444e742f80d8e0f7d052579599fe07905622c46f45b599d42556380d52af9R125) [[13]](diffhunk://#diff-fdb444e742f80d8e0f7d052579599fe07905622c46f45b599d42556380d52af9R581-R583) [[14]](diffhunk://#diff-fdb444e742f80d8e0f7d052579599fe07905622c46f45b599d42556380d52af9L588-R593) [[15]](diffhunk://#diff-8dd2543dcd10552bd1c84fc8ac96b0245a73f83163b90782ca0b84ad35ddcf82R6) [[16]](diffhunk://#diff-8dd2543dcd10552bd1c84fc8ac96b0245a73f83163b90782ca0b84ad35ddcf82R104)

**Version updates:**

* Bumped patch version from `1.5.1` to `1.5.2` for the following packages: `accordion`, `alert-dialog`, `aspect-ratio`, `avatar`, `checkbox`, `collapsible`, `context-menu`, `dialog`, `dropdown-menu`, `hooks`, `hover-card`, `label`, and `menubar`. [[1]](diffhunk://#diff-8f2f904ea6829ea585414044805fa5388ffc50556e0422a79dad76f80a9d3537L3-R3) [[2]](diffhunk://#diff-df4f5210a69989db377c1bfb582f4adb73692df176abdc092a3ccdb6a59174caL3-R3) [[3]](diffhunk://#diff-511cd68ef0cb83dd9f7c9fb97fa70e3b440b849dfc8a4af14b3da43603cc065dL3-R3) [[4]](diffhunk://#diff-768ac97ebc8c76fdecfcbe30494b48fc5a4806e88c8040e7c9446ebdb8e5ef7bL3-R3) [[5]](diffhunk://#diff-d18b890cc5cf038168685855db8acf4344fc30948f0fde92a2a7a7fd2a02d85bL3-R3) [[6]](diffhunk://#diff-58ec10d33eee4a23487de767dfce4e6ff38e56cf9a383050b54254398ad2e24fL3-R3) [[7]](diffhunk://#diff-4fc41f277a432574dfed419b1c5a88e8da412c2ba639216911e929da690eeafbL3-R3) [[8]](diffhunk://#diff-f85dd2108967dae1d77738242ab972df9d3fefc3a8567f0721607068ceb0aad9L3-R3) [[9]](diffhunk://#diff-9830b332ea9e6f9c17c91b24616c5d2e8435840ddb649860ac8c376e38cccd16L3-R3) [[10]](diffhunk://#diff-b6d356593637334512ec805d998a47159ea74bb67210d0df7e8fd1ba10739ac1L3-R3) [[11]](diffhunk://#diff-e1cf0c081b0b28985ac7d3b900954ebf0df93d700139a350afba28c2c9c3f709L3-R3) [[12]](diffhunk://#diff-c941974c1fa086b85fb3c5c942072d438368a4426b41c5f4c08a60d9be9445b7L3-R3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accessibility focus restoration across several interactive components, helping keyboard and screen reader users return to the triggering control after menus, dialogs, popovers, tooltips, and similar overlays close.
  * Exposed a reusable focus-restoration helper for use across the library.

* **Chores**
  * Bumped package versions to the latest patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->