### PR TITLE
fix(portal): key PortalHost entries by portal name to prevent cross-portal state transfer on removal

### DIFF
--- a/.changeset/keyed-portal-host.md
+++ b/.changeset/keyed-portal-host.md
@@ -1,0 +1,5 @@
+---
+'@rn-primitives/portal': patch
+---
+
+Fix `PortalHost` scrambling the remaining portals when one portal unmounts. Portals were rendered as a keyless fragment, so React reconciled them by array position: removing a portal slid every later portal onto its predecessor's component instances, silently transferring state between same-type portals (e.g. two bottom sheets or dialogs) and remounting diverging ones. Each portal's subtree is now keyed by its portal name, making removals local to the removed portal.

--- a/packages/portal/src/portal.tsx
+++ b/packages/portal/src/portal.tsx
@@ -33,7 +33,17 @@ const removePortal = (hostName: string, name: string) => {
 export function PortalHost({ name = DEFAULT_PORTAL_HOST }: { name?: string }) {
   const portalMap = usePortal((state) => state.map).get(name) ?? new Map<string, React.ReactNode>();
   if (portalMap.size === 0) return null;
-  return <>{Array.from(portalMap.values())}</>;
+  // Key each portal's subtree by its portal name. A keyless fragment makes React
+  // reconcile portals by array position, so removing one portal slides every later
+  // portal onto its predecessor's component instances: same-type nodes silently
+  // inherit the predecessor's state and diverging nodes are torn down and remounted.
+  return (
+    <>
+      {Array.from(portalMap.entries()).map(([portalName, children]) => (
+        <React.Fragment key={portalName}>{children}</React.Fragment>
+      ))}
+    </>
+  );
 }
 
 export function Portal({


### PR DESCRIPTION
## Bug

`PortalHost` renders its registered portals as a keyless fragment:

```tsx
return <>{Array.from(portalMap.values())}</>;
```

Without keys, React reconciles the children by array position. When a portal is removed, every portal registered after it slides one position down and is reconciled against its predecessor's element:

- If the two portals render the same component type at the root (very common — e.g. every bottom sheet / dialog in an app renders through the same wrapper component), the later portal's tree **adopts the removed portal's neighbor state**: internal refs, animated values, measured layouts, open/closed state, etc. silently transfer between unrelated portals.
- If the trees diverge in type, the later portal is torn down and **remounted from scratch**, losing all of its state.

This is invisible while portal membership is static, but bites as soon as portals mount/unmount dynamically (e.g. a sheet that mounts on open and unmounts after close): closing one sheet scrambles or remounts every sheet registered after it in the same host.

### Repro sketch

```tsx
<PortalHost />

{showA && (
  <Portal name='sheet-a'>
    <MySheet /* ... */ />
  </Portal>
)}
<Portal name='sheet-b'>
  <MySheet /* ... */ />
</Portal>
```

Toggle `showA` off while both are registered: `sheet-b`'s subtree is reconciled onto `sheet-a`'s old component instances and inherits their state (or remounts, if the trees diverge). With `@gorhom/bottom-sheet` content this shows up as sheets losing their footer, inheriting another sheet's snap position, or disappearing when an unrelated sheet closes.

## Fix

Key each portal's subtree by its portal name, which is already unique per host:

```tsx
return (
  <>
    {Array.from(portalMap.entries()).map(([portalName, children]) => (
      <React.Fragment key={portalName}>{children}</React.Fragment>
    ))}
  </>
);
```

Removals become local to the removed portal; the other portals keep their component instances. No public API change. A changeset (patch bump for `@rn-primitives/portal`) is included.

Verified with `pnpm --filter @rn-primitives/portal build` and, in a production app, with a regression test that mounts two same-type portal subtrees, removes the first, and asserts the second neither remounts nor swaps component instances — it fails on the keyless host and passes with this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where removing one portal could cause other displayed portals to be rearranged or show incorrect content.
  * Improved portal rendering stability when portals are added or removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->